### PR TITLE
Add a project npm config registry entry for @rifflearning scoped packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,19 @@ jobs:
     name: Build Frontend
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-    - run: npm install
-    - run: npm run lint
-    - run: make
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+          registry-url: https://npm.pkg.github.com/
+
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies based on package-lock.json
+        run: npm ci
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GPR_PRIVATE_READ_TOKEN }}
+
+      - run: npm run lint
+
+      - run: make

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=true
+@rifflearning:registry=https://npm.pkg.github.com/


### PR DESCRIPTION
## Description
Added an entry in the project `.npmrc` file that specifies that `@rifflearning` scoped packages should be retrieved from the GitHub Package Registry `https://npm.pkg.github.com`

Each developer will still have to have set authorized access to https://npm.pkg.github.com
see https://docs.github.com/en/packages/guides/configuring-npm-for-use-with-github-packages
TL;DR: add this line with a github token created by the developer to `~/.npmrc`
```
//npm.pkg.github.com/:_authToken=TOKEN
```

## Motivation and context
This project now uses `@rifflearning` scoped packages. While some public `@rifflearning` packages are available in the standard npm registry, there will soon be others used which are private and only available from the GitHub Package Registry.

## How has this been tested?
I did an `npm install` on my local dev machine. This PR is the 1st test of the GitHub Action workflow, and it may need some changes as well.

## Types of changes
- ✅ Maintenance (change which doesn't modify functionality, but provides dependency updates or tooling improvements)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

