### PR TITLE
show participants names by default in video conference

### DIFF
--- a/css/riff-styles.scss
+++ b/css/riff-styles.scss
@@ -62,6 +62,10 @@ body > .tooltip {
     box-sizing: border-box;
 }
 
+.videocontainer__toolbar {
+    background-image: linear-gradient(to top,rgba(0,0,0,.6),rgba(0,0,0,0));
+}
+
 // fix bottom difference between indicators for using text-overflow: ellipsis
 .indicator-container {
     overflow: hidden;

--- a/css/riff-styles.scss
+++ b/css/riff-styles.scss
@@ -61,3 +61,55 @@ body > .tooltip {
     width: 50% !important;
     box-sizing: border-box;
 }
+
+// fix bottom difference between indicators for using text-overflow: ellipsis
+.indicator-container {
+    overflow: hidden;
+}
+
+.indicator-container:nth-child(1) .username-indicator {
+    margin-left: 0;
+}
+
+.username-indicator-container {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 60%;
+    
+    &.username-indicator-filmstrip-view {
+        float: left !important;
+
+        .username-indicator {
+            margin-left: 10px;
+        }
+    }
+
+    div {
+        display: inline;
+    }
+}
+
+#localVideoContainer {
+
+    .username-indicator-filmstrip-view .username-indicator {
+        margin-left: 0;
+    }
+}
+
+.username-indicator {
+    font-size: 8pt;
+    text-align: center;
+    color: #fff;
+    width: 12px;
+    line-height: 22px;
+    height: 22px;
+    padding: 0;
+    border: 0;
+    margin: 0 5px 0 5px;
+}
+
+// Participant name by default always show on video container
+// in order to improve the user experience.  
+.displayNameContainer {
+  display: none;
+}

--- a/react/features/filmstrip/components/web/StatusIndicators.js
+++ b/react/features/filmstrip/components/web/StatusIndicators.js
@@ -4,6 +4,7 @@ import React, { Component } from 'react';
 
 import { getLocalParticipant, getParticipantById, PARTICIPANT_ROLE } from '../../../base/participants';
 import { connect } from '../../../base/redux';
+import DisplayParticipantNameIndicator from '../../../riff-platform/components/DisplayParticipantNameIndicator';
 import { getCurrentLayout, LAYOUTS } from '../../../video-layout';
 
 import AudioMutedIndicator from './AudioMutedIndicator';
@@ -79,6 +80,10 @@ class StatusIndicators extends Component<Props> {
             <div>
                 { showAudioMutedIndicator ? <AudioMutedIndicator tooltipPosition = { tooltipPosition } /> : null }
                 { showVideoMutedIndicator ? <VideoMutedIndicator tooltipPosition = { tooltipPosition } /> : null }
+                <DisplayParticipantNameIndicator
+                    participantId = { this.props.participantID }
+                    tileView = { _currentLayout }
+                    tooltipPosition = { tooltipPosition } />
                 { _showModeratorIndicator ? <ModeratorIndicator tooltipPosition = { tooltipPosition } /> : null }
             </div>
         );

--- a/react/features/riff-platform/components/DisplayParticipantNameIndicator.js
+++ b/react/features/riff-platform/components/DisplayParticipantNameIndicator.js
@@ -1,0 +1,48 @@
+
+import Tooltip from '@atlaskit/tooltip';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { getParticipantDisplayName } from '../../base/participants';
+import { connect } from '../../base/redux';
+import { LAYOUTS } from '../../video-layout';
+
+
+const DisplayParticipantNameIndicator = ({ tooltipPosition = 'bottom', participantDisplayName, tileView }) => {
+    let displayName = participantDisplayName;
+    let usernameContainerClassName = '';
+
+    if (tileView === LAYOUTS.VERTICAL_FILMSTRIP_VIEW) {
+        displayName = participantDisplayName.split(' ')[0];
+        usernameContainerClassName = 'username-indicator-filmstrip-view';
+    }
+
+    return (
+        <div className = { `indicator-container username-indicator-container ${usernameContainerClassName}` }>
+            <Tooltip
+                content = { 'Participant name' }
+                position = { tooltipPosition }>
+                <span
+                    className = { 'username-indicator' }>
+                    {displayName}
+                </span>
+            </Tooltip>
+        </div>
+    );
+};
+
+DisplayParticipantNameIndicator.propTypes = {
+    participantDisplayName: PropTypes.string,
+    tileView: PropTypes.string,
+    tooltipPosition: PropTypes.string
+};
+
+const mapStateToProps = (state, ownProps) => {
+    const { participantId } = ownProps;
+
+    return {
+        participantDisplayName: getParticipantDisplayName(state, participantId) || ''
+    };
+};
+
+export default connect(mapStateToProps)(DisplayParticipantNameIndicator);


### PR DESCRIPTION
## Description
Added participant name to the conference video container instead of showing only when hovered.

## Motivation and context
Issue: https://riffanalytics.atlassian.net/browse/ODIN-11

## Screenshots (if appropriate):
![Screenshot from 2021-04-08 15-29-50](https://user-images.githubusercontent.com/75265731/114027349-f09cab80-987f-11eb-8d0d-a84d6673bc79.png)
![Screenshot from 2021-04-08 15-55-20](https://user-images.githubusercontent.com/75265731/114030958-8c7be680-9883-11eb-862c-b75cca0f8b4a.png)
![Screenshot from 2021-04-08 15-29-13](https://user-images.githubusercontent.com/75265731/114027401-fbefd700-987f-11eb-8109-ee1d3323f3be.png)

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
