### PR TITLE
show presenter video if user used camera before screen sharing

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1854,6 +1854,7 @@ export default {
         if (this.videoSwitchInProgress) {
             return Promise.reject('Switch in progress.');
         }
+        const didHaveVideo = !this.isLocalVideoMuted();
 
         this.videoSwitchInProgress = true;
 
@@ -1888,6 +1889,12 @@ export default {
                 }
                 sendAnalytics(createScreenSharingEvent('started'));
                 logger.log('Screen sharing started');
+
+                // if there was a camera video being used, before switching to screen sharing,
+                // show presenter video
+                if (didHaveVideo) {
+                    this.muteVideo(false);
+                }
             })
             .catch(error => {
                 this.videoSwitchInProgress = false;


### PR DESCRIPTION
## Description
Presenter video is shown if there was a camera video being used, before switching to screen sharing

## Motivation and context
Issue: https://riffanalytics.atlassian.net/browse/ODIN-10

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**.
