### PR TITLE
add version to import links so that changes are reloaded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,14 +142,18 @@ source-package-files: ## copy all files needed for distribution (built and stati
 	cd source_package/jitsi-meet ; rm $(NOT_SRC_PKG_FILES)
 	cp css/all.css source_package/jitsi-meet/css
 
-source-package-version: ## add versioning to all.css and app.bundle.min.js imports in index.html
+source-package-version: ## add versioning to all.css, app.bundle.min.js and other imports in index.html
 source-package-version: SHASUM_ALL_CSS = $(shell shasum ./css/all.css | cut -c -8)
 source-package-version: SHASUM_APP_BUNDLE = $(shell shasum ./libs/app.bundle.min.js | cut -c -8)
+source-package-version: SHASUM_LIB_JITSI_MEET = $(shell shasum ./libs/lib-jitsi-meet.min.js | cut -c -8)
+source-package-version: SHASUM_DO_EXTERNAL_CONNECT = $(shell shasum ./libs/do_external_connect.min.js | cut -c -8)
 source-package-version: source-package-files
 	@cd source_package/jitsi-meet ; \
 	echo "versioning all.css (v=$(SHASUM_ALL_CSS)) and app.bundle.min.js (v=$(SHASUM_APP_BUNDLE)) in index.html" ; \
 	sed -e 's/css\/all.css/&?v='$(SHASUM_ALL_CSS)'/' \
 		-e 's/\(app\.bundle\.min\.js\)?v=[0-9]\+/\1?v='$(SHASUM_APP_BUNDLE)'/' \
+		-e 's/\(lib-jitsi-meet\.min\.js\)?v=[0-9]\+/\1?v='$(SHASUM_LIB_JITSI_MEET)'/' \
+		-e 's/\(do_external_connect\.min\.js\)?v=[0-9]\+/\1?v='$(SHASUM_DO_EXTERNAL_CONNECT)'/' \
 		--in-place index.html
 
 dev-package: ## create package using working dir code and existing env settings for development deployment


### PR DESCRIPTION
## Description
We already added a "version" (actually hash) for the `all.css` and `app.bundle.min.js` files when they are loaded from `index.html`.

We are now also adding a version to `lib-jitsi-meet.min.js` and `do_external_connect.min.js` when they are loaded.

The purpose of adding this version is so that a new version will always be reload from the instance and not found in the browser cache.

I also have modified the set of files packaged for deployment and removed 2 unneeded files `webpack.config.js` and `babel.config.js`.

## Motivation and context
After merging in the latest core jitsi-meet changes, it was noticed that there were issues if users did not force reload all of the site. @jordanreedie determined it was due to some of these other files having changed. By adding the versions, the next time these other files change (probably not until we merge in more core changes), our users should have a more seamless experience and these files will automatically get reloaded because their versions will have changed.

fixes: [RIFF-418](https://riffanalytics.atlassian.net/browse/RIFF-418)

## How has this been tested?
This was only tested to verify that the expected new versions were being updated on the links in the index.html file.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
