### PR TITLE
update riff metrics to version 2.0.0

### DIFF
--- a/css/_riff-metrics.scss
+++ b/css/_riff-metrics.scss
@@ -6,11 +6,3 @@
     $meeting-info-title-color: white,
     $meeting-info-details-color: #ffffffcc,
 );
-
-.amcharts-legend-container .legend-item .label {
-    background: unset;
-}
-
-.empty-graph-text {
-    color: #4a4a4a;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2207,23 +2207,23 @@
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/react": {
-      "version": "11.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.0.tgz",
-      "integrity": "sha512-4XklWsl9BdtatLoJpSjusXhpKv9YVteYKh9hPKP1Sxl+mswEFoUe0WtmtWjxEjkA51DQ2QRMCNOvKcSlCQ7ivg==",
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.4.1.tgz",
+      "integrity": "sha512-pRegcsuGYj4FCdZN6j5vqCALkNytdrKw3TZMekTzNXixRg4wkLsU5QEaBG5LC6l01Vppxlp7FE3aTHpIG5phLg==",
       "requires": {
         "@babel/runtime": "^7.13.10",
         "@emotion/cache": "^11.4.0",
         "@emotion/serialize": "^1.0.2",
-        "@emotion/sheet": "^1.0.1",
+        "@emotion/sheet": "^1.0.2",
         "@emotion/utils": "^1.0.0",
         "@emotion/weak-memoize": "^0.2.5",
         "hoist-non-react-statics": "^3.3.1"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-          "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
+          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2253,9 +2253,9 @@
           }
         },
         "@emotion/sheet": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
-          "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.2.tgz",
+          "integrity": "sha512-QQPB1B70JEVUHuNtzjHftMGv6eC3Y9wqavyarj4x4lg47RACkeSfNo5pxIOKizwS9AEFLohsqoaxGQj4p0vSIw=="
         },
         "@emotion/utils": {
           "version": "1.0.0",
@@ -2773,6 +2773,78 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.0.tgz",
       "integrity": "sha512-8cUA/mg0S+BxIZ72TdZRsXKBP5n5uRcE3k29TZhZw6oIiHBt9JA7CTb/4pE1uKtE/q5NeTY2tBDcagoZ+1zjXQ=="
+    },
+    "@foliojs-fork/fontkit": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/fontkit/-/fontkit-1.9.1.tgz",
+      "integrity": "sha512-U589voc2/ROnvx1CyH9aNzOQWJp127JGU1QAylXGQ7LoEAF6hMmahZLQ4eqAcgHUw+uyW4PjtCItq9qudPkK3A==",
+      "requires": {
+        "@foliojs-fork/restructure": "^2.0.2",
+        "brfs": "^2.0.0",
+        "brotli": "^1.2.0",
+        "browserify-optional": "^1.0.1",
+        "clone": "^1.0.4",
+        "deep-equal": "^1.0.0",
+        "dfa": "^1.2.0",
+        "tiny-inflate": "^1.0.2",
+        "unicode-properties": "^1.2.2",
+        "unicode-trie": "^2.0.0"
+      },
+      "dependencies": {
+        "unicode-trie": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+          "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+          "requires": {
+            "pako": "^0.2.5",
+            "tiny-inflate": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@foliojs-fork/linebreak": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/linebreak/-/linebreak-1.1.1.tgz",
+      "integrity": "sha512-pgY/+53GqGQI+mvDiyprvPWgkTlVBS8cxqee03ejm6gKAQNsR1tCYCIvN9FHy7otZajzMqCgPOgC4cHdt4JPig==",
+      "requires": {
+        "base64-js": "1.3.1",
+        "brfs": "^2.0.2",
+        "unicode-trie": "^2.0.0"
+      },
+      "dependencies": {
+        "unicode-trie": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+          "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+          "requires": {
+            "pako": "^0.2.5",
+            "tiny-inflate": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@foliojs-fork/pdfkit": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/pdfkit/-/pdfkit-0.12.3.tgz",
+      "integrity": "sha512-WAMiL5Dp1EdHyuEeVphiqVeFEaccGShS5wLcuOXFF0wlBE5agkvTEk3sJ2OfAn87FaStpkuiaiSKNRexMlNHUA==",
+      "requires": {
+        "@foliojs-fork/fontkit": "^1.9.1",
+        "@foliojs-fork/linebreak": "^1.1.1",
+        "crypto-js": "^4.0.0",
+        "png-js": "^1.0.0"
+      },
+      "dependencies": {
+        "crypto-js": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+          "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+        }
+      }
+    },
+    "@foliojs-fork/restructure": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@foliojs-fork/restructure/-/restructure-2.0.2.tgz",
+      "integrity": "sha512-59SgoZ3EXbkfSX7b63tsou/SDGzwUEK6MuB5sKqgVK1/XE0fxmpsOb9DQI8LXW3KfGnAjImCGhhEb7uPPAUVNA=="
     },
     "@grpc/grpc-js": {
       "version": "1.3.4",
@@ -3380,11 +3452,14 @@
       "integrity": "sha512-lagdZr9UiVAccNXYfTEj+aUcPCx9ykbMe9puffeIyF3JsRuMmlu3BjHYx1klUHX7wNRmFNC8qVP0puxUt1sZ0A=="
     },
     "@rifflearning/riff-metrics": {
-      "version": "1.2.0-dev.1",
-      "resolved": "https://npm.pkg.github.com/download/@rifflearning/riff-metrics/1.2.0-dev.1/09cfa1d46de8b067db2be864c0ff83a3c979e272d928d8a0a797bef25eaed772",
-      "integrity": "sha512-ZXMNY+JAzVZT+RWoGGoobv9+IHyUCYYJde2nEiRrT4iuUUgGgeurQkobN9Sy6QxrP1L9+HKGEyHixb5vgvbGIA==",
+      "version": "2.0.0",
+      "resolved": "https://npm.pkg.github.com/download/@rifflearning/riff-metrics/2.0.0/1a6b07b748802f747796bb9f6998e96f1256957d2a31339e423cfd1ab9077e2a",
+      "integrity": "sha512-djwf9Vj4A8PuQW+7P7ujt6xquw++UmXwkMAjkcbZ6gdtGStnKuK1W8yp8E/XeZ3J0+ZaWCD6rvaWgs2CZAY5oQ==",
       "requires": {
-        "@amcharts/amcharts4": "^4.10.20",
+        "@amcharts/amcharts4": "^4.10.21",
+        "@feathersjs/authentication-client": "^4.5.11",
+        "@feathersjs/feathers": "^4.5.11",
+        "@feathersjs/socketio-client": "^4.5.11",
         "@material-ui/icons": "^4.11.2",
         "d3-scale": "^4.0.0",
         "d3-selection": "^3.0.0",
@@ -3393,9 +3468,41 @@
         "d3-transition": "^3.0.1",
         "react-spinners": "^0.11.0",
         "react-sticky-box": "^0.9.3",
-        "reselect": "^4.0.0"
+        "reselect": "^4.0.0",
+        "socket.io-client": "^2.4.0"
       },
       "dependencies": {
+        "@amcharts/amcharts4": {
+          "version": "4.10.22",
+          "resolved": "https://registry.npmjs.org/@amcharts/amcharts4/-/amcharts4-4.10.22.tgz",
+          "integrity": "sha512-Z/vPGKtNf1m4sdKK1P4San8SAG1AuYJ0tLhptUqntb4u+kRfRbU2QydIGsVmpHPENLg17ukIWySwo6mv3by/tw==",
+          "requires": {
+            "@babel/runtime": "^7.6.3",
+            "core-js": "^3.0.0",
+            "d3-force": "^2.0.1",
+            "d3-geo": "^2.0.1",
+            "d3-geo-projection": "^3.0.0",
+            "pdfmake": "^0.2.2",
+            "polylabel": "^1.0.2",
+            "raf": "^3.4.1",
+            "regression": "^2.0.1",
+            "rgbcolor": "^1.0.1",
+            "stackblur-canvas": "^2.0.0",
+            "tslib": "^2.0.1",
+            "venn.js": "^0.2.20",
+            "xlsx": "^0.17.0"
+          }
+        },
+        "codepage": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
+          "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="
+        },
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="
+        },
         "d3-scale": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.0.tgz",
@@ -3439,6 +3546,35 @@
             "d3-ease": "1 - 3",
             "d3-interpolate": "1 - 3",
             "d3-timer": "1 - 3"
+          }
+        },
+        "pdfmake": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.2.2.tgz",
+          "integrity": "sha512-e1N+iIIf0LXTvfmf/RaxeqtOKX2qFrNxBbcWmMcg2BUsgcye1bLkdxR7PImmRs8OnqT7qd9XonltZgdTFw8qUA==",
+          "requires": {
+            "@foliojs-fork/linebreak": "^1.1.1",
+            "@foliojs-fork/pdfkit": "^0.12.3",
+            "iconv-lite": "^0.6.3",
+            "svg-to-pdfkit": "^0.1.8",
+            "xmldoc": "^1.1.2"
+          }
+        },
+        "xlsx": {
+          "version": "0.17.1",
+          "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.17.1.tgz",
+          "integrity": "sha512-SrvK+kMEjiVIKYyJSjSIJwzm2cZn8nQWVh708g7O+pTsmgjoa+uYNLEUn7jmwQdMI/ffCHcY5yEvwBXssBwpRA==",
+          "requires": {
+            "adler-32": "~1.2.0",
+            "cfb": "^1.1.4",
+            "codepage": "~1.15.0",
+            "commander": "~2.17.1",
+            "crc-32": "~1.2.0",
+            "exit-on-epipe": "~1.0.1",
+            "fflate": "^0.3.8",
+            "ssf": "~0.11.2",
+            "wmf": "~1.0.1",
+            "word": "~0.3.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@react-native-async-storage/async-storage": "1.13.2",
     "@react-native-community/google-signin": "3.0.1",
     "@react-native-community/netinfo": "4.1.5",
-    "@rifflearning/riff-metrics": "^1.2.0-dev.1",
+    "@rifflearning/riff-metrics": "^2.0.0",
     "@rifflearning/sibilant": "^0.1.7",
     "@svgr/webpack": "4.3.2",
     "amplitude-js": "8.2.1",


### PR DESCRIPTION
## Description
Update to the latest released version of the @rifflearning/riff-metrics package 2.0.0 (see the [changelog](https://github.com/rifflearning/riff-metrics/blob/v2.0.0/CHANGELOG.md)) from the prerelease version we have been using)

## Motivation and context
We want to stay up-to-date, AND there are new features that we want to take advantage of, such as the new experimental metrics/dashboard, and some riffdata server client connection features.

## How has this been tested?
This was built and installed on a test instance in AWS.

## Types of changes
- ✅ Maintenance (change which doesn't modify functionality, but provides dependency updates or tooling improvements)
- ✅ Refactor (non-breaking change which doesn't change functionality)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

