### PR TITLE
Update riff-metrics package to version 2.1.0

### DIFF
--- a/css/_riff-metrics.scss
+++ b/css/_riff-metrics.scss
@@ -6,28 +6,3 @@
     $meeting-info-title-color: white,
     $meeting-info-details-color: #ffffffcc,
 );
-
-.dashboard-header-container .header {
-    color: white;
-}
-
-.meeting-info-component {
-    .meeting-details {
-        h2 {
-            font-size: 16px;
-            margin-top: 0;
-            color: inherit;
-        }
-    }
-}
-
-.dashboard-view-component {
-    font-family: sans-serif;
-    // TODO: these changes are not needed visually -mjl 2021-08-30
-    .chart-card-container {
-        .chart-card-title {
-            line-height: 1.75;
-            margin-bottom: 20px;
-        }
-    }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2221,9 +2221,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.15.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.3.tgz",
-          "integrity": "sha512-OvwMLqNXkCXSz1kSm58sEsNuhqOx/fKpnUnKnFB5v8uDda5bLNEHNgKPvhDN6IU0LDcnHQ90LlJ0Q6jnyBSIBA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
+          "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2263,9 +2263,9 @@
           "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
         },
         "csstype": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.8.tgz",
-          "integrity": "sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw=="
+          "version": "3.0.9",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+          "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
         },
         "stylis": {
           "version": "4.0.10",
@@ -3452,11 +3452,11 @@
       "integrity": "sha512-lagdZr9UiVAccNXYfTEj+aUcPCx9ykbMe9puffeIyF3JsRuMmlu3BjHYx1klUHX7wNRmFNC8qVP0puxUt1sZ0A=="
     },
     "@rifflearning/riff-metrics": {
-      "version": "2.0.0",
-      "resolved": "https://npm.pkg.github.com/download/@rifflearning/riff-metrics/2.0.0/1a6b07b748802f747796bb9f6998e96f1256957d2a31339e423cfd1ab9077e2a",
-      "integrity": "sha512-djwf9Vj4A8PuQW+7P7ujt6xquw++UmXwkMAjkcbZ6gdtGStnKuK1W8yp8E/XeZ3J0+ZaWCD6rvaWgs2CZAY5oQ==",
+      "version": "2.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@rifflearning/riff-metrics/2.1.0/61494c177825976f79eb381020f5e9df6225b07d9e70eaf1947432036258c7f2",
+      "integrity": "sha512-34gJdHWtb+aVQu6mQ1ghR2P5rznQdk+xTpRDuo/c7AjfkOHCTsX12s4M5ScWfEiNnFSJGtrTWRT3+28TiqqRYA==",
       "requires": {
-        "@amcharts/amcharts4": "^4.10.21",
+        "@amcharts/amcharts4": "^4.10.22",
         "@feathersjs/authentication-client": "^4.5.11",
         "@feathersjs/feathers": "^4.5.11",
         "@feathersjs/socketio-client": "^4.5.11",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@react-native-async-storage/async-storage": "1.13.2",
     "@react-native-community/google-signin": "3.0.1",
     "@react-native-community/netinfo": "4.1.5",
-    "@rifflearning/riff-metrics": "^2.0.0",
+    "@rifflearning/riff-metrics": "^2.1.0",
     "@rifflearning/sibilant": "^0.1.7",
     "@svgr/webpack": "4.3.2",
     "amplitude-js": "8.2.1",


### PR DESCRIPTION
## Description
This PR updates jitsi-meet to use version 2.1.0 of the metrics package. Additionally, override styles that are no longer needed (i.e. those which have been added to the metrics package) have been removed.

## Motivation and context
We needed to update jitsi to use the latest metrics package release and removing the now unnecessary styles reduces technical debt. 

## How has this been tested?
This has been tested by running jitsi-meet locally. 

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**