### PR TITLE
BugFix: display participant name in low bandwidth sharing mode

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1209,7 +1209,7 @@ export default {
         const displayName = getDisplayName(id);
 
         if (displayName) {
-            return maybeExtractIdFromDisplayName(displayName).didisplayName;
+            return maybeExtractIdFromDisplayName(displayName).displayName;
         }
         if (APP.conference.isLocalId(id)) {
             return APP.translation.generateTranslationHTML(


### PR DESCRIPTION
Display participant name in low bandwidth sharing mode

## How has this been tested?
This has been tested locally.

## Screenshots (if appropriate):
![Screenshot from 2021-10-01 14-57-27](https://user-images.githubusercontent.com/75265731/135616230-feeb15b0-288d-49a7-b75a-e4f6868983da.png)

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**-
