### PR TITLE
Bug fix in sibilantActions 

### DIFF
--- a/react/features/riff-platform/actions/sibilantActions.js
+++ b/react/features/riff-platform/actions/sibilantActions.js
@@ -86,8 +86,8 @@ function riffAddUserToMeeting({ uid, displayName, context = '' }, room, token, t
             });
 
             const meetingListener = meeting => {
-                if (meeting.active && meeting.room === room && meeting.participants.include(uid)) {
-                    meeting.removeListener('patched', meetingListener);
+                if (meeting.active && meeting.room === room && meeting.participants.includes(uid)) {
+                    app.service('meetings').removeListener('patched', meetingListener);
                     dispatch(setRoomIdFromRiffDataServer(meeting._id));
                 }
             };


### PR DESCRIPTION
## Description
This PR fixes a bug created in PR#114 where the event listener was not being properly removed. 

## Motivation and context
It was a bug that needed to be fixed.

## How has this been tested?
This was tested by running jitsi in sandbox1. Console errors present prior to the fix are no longer there and the participant is still removed successfully from the meeting when the tab is closed as was observed in the docker logs.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
