### PR TITLE
Add a feature flag for starting presenter mode by default

### DIFF
--- a/conference.js
+++ b/conference.js
@@ -1,4 +1,4 @@
-/* global APP, JitsiMeetJS, config, interfaceConfig */
+/* global APP, JitsiMeetJS, config, interfaceConfig, riffConfig */
 
 import { jitsiLocalStorage } from '@jitsi/js-utils';
 import EventEmitter from 'events';
@@ -1937,7 +1937,7 @@ export default {
 
                 // if there was a camera video being used, before switching to screen sharing,
                 // show presenter video
-                if (didHaveVideo) {
+                if (didHaveVideo && riffConfig.enablePresenterModeByDefault) {
                     this.muteVideo(false);
                 }
             })

--- a/riff_config.js
+++ b/riff_config.js
@@ -39,6 +39,13 @@ const riffConfig = {
     meeting: {
         /** should the meeting mediator be available */
         enableMeetingMediator: true,
+
+        /**
+         * should we start the user in 'presenter mode'
+         * when they share their screen?
+         */
+        enablePresenterModeByDefault: false,
+
         showMediatorOnJoinRegistered: true,
         showMediatorOnJoinAnonymous: true
     },


### PR DESCRIPTION
## Description
Adds a config setting in riff_config.js to enable or disable the starting of presenter mode during screen sharing by default. This probably should have been a feature branch in retrospect since I'm not technically fixing anything right now, but that didn't occur to me until I was already writing up this PR. 

## Motivation and context
We currently have a theory that the change to start presenter mode by default is resulting in instability in our screen sharing feature. Plus, being able to toggle this feature is beneficial regardless of whether or not this is actually causing the issue.

## How has this been tested?
Tested on sandbox1 

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
