### PR TITLE
RA-317 Fixed Info Button on Meeting Mediator

### DIFF
--- a/css/riff-styles.scss
+++ b/css/riff-styles.scss
@@ -43,9 +43,9 @@ html body {
         right: 0;
         color: #4a4a4a;
         cursor: pointer;
-        height: 24px;
-        width: 24px;
-        padding: 5px;
+        margin: 2px;
+        height: 16px;
+        width: 16px;
         z-index: 1;
 
         svg {


### PR DESCRIPTION
## Description
Fixed the meeting mediator's info button which was closing the meeting mediator on click because of overlap with the close button. This issue was resolved by switching `padding` to `margin` in the `meeting-mediator-close`'s styling.  

## Motivation and context
This was a bug; jira ticket was [RA-317](https://riffanalytics.atlassian.net/browse/RA-317)

## How has this been tested?
This has been tested by deploying jitsi to sandbox1.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
