### PR TITLE
RA-318: Guest User's Name Can't Be a Space 

### DIFF
--- a/react/features/base/premeeting/components/web/InputField.js
+++ b/react/features/base/premeeting/components/web/InputField.js
@@ -166,6 +166,10 @@ export default class InputField extends PureComponent<Props, State> {
     _onChange(evt) {
         const value = getFieldValue(evt);
 
+        // if (value.trim().length === 0) {
+        //     value = '';
+        // }
+
         this.setState({
             value
         });

--- a/react/features/base/premeeting/components/web/Preview.js
+++ b/react/features/base/premeeting/components/web/Preview.js
@@ -81,7 +81,7 @@ function _mapStateToProps(state, ownProps) {
     return {
         _participantId,
         flipVideo: state['features/base/settings'].localFlipX,
-        name,
+        name: name.trim(),
         videoMuted: ownProps.videoTrack ? ownProps.videoMuted : state['features/base/media'].video.muted,
         videoTrack: ownProps.videoTrack || (getLocalVideoTrack(state['features/base/tracks']) || {}).jitsiTrack
     };

--- a/react/features/prejoin/components/Prejoin.js
+++ b/react/features/prejoin/components/Prejoin.js
@@ -390,7 +390,8 @@ class Prejoin extends Component<Props, State> {
                                 ariaDropDownLabel = { t('prejoin.joinWithoutAudio') }
                                 ariaLabel = { t('prejoin.joinMeeting') }
                                 ariaPressed = { showJoinByPhoneButtons }
-                                disabled = { joinButtonDisabled || (isAnon && !displayName) }
+                                disabled = { joinButtonDisabled
+                                    || (isAnon && (!displayName || (displayName.trim().length === 0))) }
                                 hasOptions = { true }
                                 onClick = { _onJoinButtonClick }
                                 onKeyPress = { _onJoinKeyPress }


### PR DESCRIPTION
## Description
This modifies the Join Meeting button's functionality so it does not perceive whitespaces as a valid entry for a guest user's inputted name. While a user can still add white space to the beginning and end of the input, the whitespace is trimmed prior to the user joining the meeting.

## Motivation and context
This resolves the [RA-318](https://riffanalytics.atlassian.net/browse/RA-318) bug.

## How has this been tested?
This has been tested by deploying to sandbox1, starting a meeting, and attempting to join the meeting as a guest user.

## Types of changes
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
