### PR TITLE
Prevent utterances being sent before meeting join & disable watermark

### DIFF
--- a/interface_config.js
+++ b/interface_config.js
@@ -162,7 +162,7 @@ var interfaceConfig = {
     SHOW_CHROME_EXTENSION_BANNER: false,
 
     SHOW_DEEP_LINKING_IMAGE: false,
-    SHOW_JITSI_WATERMARK: true,
+    SHOW_JITSI_WATERMARK: false,
     SHOW_POWERED_BY: false,
     SHOW_PROMOTIONAL_CLOSE_PAGE: false,
 

--- a/react/features/riff-integration/functions.js
+++ b/react/features/riff-integration/functions.js
@@ -65,8 +65,8 @@ function getRiffState(state) {
  */
 async function sendUtteranceToRiffDataServer(data, getState) {
     const state = getState();
-    const conference = state['features/base/conference'];
-    const isUserInMeeting = conference !== undefined && conference.room !== null;
+    const { conference } = state['features/base/conference'];
+    const isUserInMeeting = conference !== undefined;
 
     if (!isUserInMeeting) {
         // this ensures we don't send any utterances before the user joins the meeting,


### PR DESCRIPTION
## Description
Fixes a bug that allowed utterances to be sent before the user joined a meeting. Also disables the jitsi watermark.

## Motivation and context
Utterances should not be recorded before a user officially joins a meeting & we don't want to display the watermark.

## How has this been tested?
Tested on sandbox2

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
