### PR TITLE
add meeting context to external api parameters (RA-666)

### DIFF
--- a/react/features/riff-integration/actionTypes.js
+++ b/react/features/riff-integration/actionTypes.js
@@ -13,6 +13,7 @@
  * ******************************************************************************/
 
 const RIFF_SET_ACCESS_TOKEN = 'RIFF_SET_ACCESS_TOKEN';
+const RIFF_SET_MEETING_CONTEXT = 'RIFF_SET_MEETING_CONTEXT';
 const RIFF_SET_MEETING_ID = 'RIFF_SET_MEETING_ID';
 const RIFF_SET_MEETING_TITLE = 'RIFF_SET_MEETING_TITLE';
 const RIFF_SET_PARTICIPANT_ID = 'RIFF_SET_PARTICIPANT_ID';
@@ -23,6 +24,7 @@ const RIFF_SET_PARTICIPANT_ID = 'RIFF_SET_PARTICIPANT_ID';
  * **************************************************************************** */
 export {
     RIFF_SET_ACCESS_TOKEN,
+    RIFF_SET_MEETING_CONTEXT,
     RIFF_SET_MEETING_ID,
     RIFF_SET_MEETING_TITLE,
     RIFF_SET_PARTICIPANT_ID,

--- a/react/features/riff-integration/actions.js
+++ b/react/features/riff-integration/actions.js
@@ -18,6 +18,7 @@ import { riffdataClient } from '@rifflearning/riff-metrics';
 
 import {
     RIFF_SET_ACCESS_TOKEN,
+    RIFF_SET_MEETING_CONTEXT,
     RIFF_SET_MEETING_ID,
     RIFF_SET_MEETING_TITLE,
     RIFF_SET_PARTICIPANT_ID,
@@ -36,6 +37,19 @@ function setRiffAccessToken(accessToken) {
     return {
         type: RIFF_SET_ACCESS_TOKEN,
         accessToken,
+    };
+}
+
+/**
+ * Redux action to set Riff meeting context
+ *
+ * @param {string} meetingContext - The meeting context
+ * @returns {Object}
+ */
+function setRiffMeetingContext(meetingContext) {
+    return {
+        type: RIFF_SET_MEETING_CONTEXT,
+        meetingContext,
     };
 }
 
@@ -130,6 +144,7 @@ function riffAddUserToMeeting() {
             participant,
             room,
             meetingTitle: title,
+            meetingContext: context,
         } = getRiffState(getState());
 
         const app = getRiffApp();
@@ -151,9 +166,7 @@ function riffAddUserToMeeting() {
                 name: displayName,
                 room,
                 title,
-
-                // TODO - context?
-                // context,
+                context,
                 token,
             });
         } catch (error) {
@@ -197,6 +210,7 @@ export {
     riffAddUserToMeeting,
     riffRemoveUserFromMeeting,
     setRiffAccessToken,
+    setRiffMeetingContext,
     setRiffMeetingId,
     setRiffMeetingTitle,
     setRiffParticipantId,

--- a/react/features/riff-integration/functions.js
+++ b/react/features/riff-integration/functions.js
@@ -29,6 +29,7 @@ let _detachSibilantFn = null;
  * {
  *     accessToken,
  *     displayName,
+ *     meetingContext,
  *     meetingId,
  *     meetingTitle,
  *     participant,
@@ -39,6 +40,7 @@ function getRiffState(state) {
     const {
         accessToken,
         participantId: participant,
+        meetingContext,
         meetingId,
         meetingTitle,
     } = state['features/riff-integration'];
@@ -48,6 +50,7 @@ function getRiffState(state) {
     return {
         accessToken,
         displayName,
+        meetingContext,
         meetingId,
         meetingTitle,
         participant,

--- a/react/features/riff-integration/middleware.js
+++ b/react/features/riff-integration/middleware.js
@@ -26,6 +26,7 @@ import {
     connectToRiffDataServer,
     riffAddUserToMeeting,
     riffRemoveUserFromMeeting,
+    setRiffMeetingContext,
     setRiffMeetingTitle,
     setRiffParticipantId,
 } from './actions';
@@ -94,6 +95,7 @@ function _updateRiffInfoFromUrl({ dispatch, getState }) {
     const urlParams = parseURLParams(getState()['features/base/connection'].locationURL);
     const urlRiffParticipantId = urlParams['riffInfo.participantId'];
     const urlRiffMeetingTitle = urlParams['riffInfo.meetingTitle'];
+    const urlRiffMeetingContext = urlParams['riffInfo.meetingContext'];
 
     if (urlRiffParticipantId) {
         dispatch(setRiffParticipantId(urlRiffParticipantId));
@@ -101,5 +103,9 @@ function _updateRiffInfoFromUrl({ dispatch, getState }) {
 
     if (urlRiffMeetingTitle) {
         dispatch(setRiffMeetingTitle(urlRiffMeetingTitle));
+    }
+
+    if (urlRiffMeetingContext) {
+        dispatch(setRiffMeetingContext(urlRiffMeetingContext));
     }
 }

--- a/react/features/riff-integration/reducer.js
+++ b/react/features/riff-integration/reducer.js
@@ -19,6 +19,7 @@ import { ReducerRegistry } from '../base/redux';
 
 import {
     RIFF_SET_ACCESS_TOKEN,
+    RIFF_SET_MEETING_CONTEXT,
     RIFF_SET_MEETING_ID,
     RIFF_SET_MEETING_TITLE,
     RIFF_SET_PARTICIPANT_ID,
@@ -29,6 +30,7 @@ const INITIAL_STATE = {
     meetingId: null,
 
     // TODO - jr - decide on initial state
+    meetingContext: '',
     meetingTitle: '',
     participantId: '',
 };
@@ -40,6 +42,12 @@ ReducerRegistry.register('features/riff-integration', (state = INITIAL_STATE, ac
         return {
             ...state,
             accessToken: action.accessToken,
+        };
+
+    case RIFF_SET_MEETING_CONTEXT:
+        return {
+            ...state,
+            meetingContext: action.meetingContext,
         };
 
     case RIFF_SET_MEETING_ID:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
The external api will now accept an additional `meetingContext` property in the `riffInfo` object. 

## Motivation and context
This is required for full riff EDU support

## How has this been tested?
Tested locally and confirmed the `context` was being sent to the riff data server when a user joins a meeting.

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ New feature (non-breaking change which adds functionality)


## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
- ✅ My change requires a change to the documentation and I have updated it accordingly.
- ✅ I have added tests to cover my changes.
