### PR TITLE
Enable always-on transcription on conference joined to collect utterance data (RA-684)

### DIFF
--- a/react/features/conference/middleware.js
+++ b/react/features/conference/middleware.js
@@ -17,6 +17,12 @@ import { setToolboxEnabled } from '../toolbox/actions';
 
 import { notifyKickedOut } from './actions';
 
+/**
+ * The local participant property which is used to set whether the local
+ * participant wants to have a transcriber in the room.
+ */
+const P_NAME_REQUESTING_TRANSCRIPTION = 'requestingTranscription';
+
 MiddlewareRegistry.register(store => next => action => {
     const result = next(action);
 
@@ -112,5 +118,28 @@ function _conferenceJoined({ dispatch, getState }) {
         getState
     });
 
+
+    // Always enable transcription because Riff requires it in order to collect utterance data
+    _setRequestingTranscription({ getState }, true);
+
     dispatch(showSalesforceNotification());
+}
+
+
+/**
+ * Set the local property 'requestingTranscription'. This will cause Jicofo
+ * and Jigasi to decide whether the transcriber needs to be in the room.
+ *
+ * @param {Store} store - The redux store.
+ * @param {boolean} enabled - The new state of the transcription.
+ * @private
+ * @returns {void}
+ */
+function _setRequestingTranscription({ getState }, enabled: boolean) {
+    const state = getState();
+    const { conference } = state['features/base/conference'];
+
+    conference.setLocalParticipantProperty(
+        P_NAME_REQUESTING_TRANSCRIPTION,
+        enabled);
 }

--- a/react/features/subtitles/middleware.js
+++ b/react/features/subtitles/middleware.js
@@ -50,15 +50,23 @@ const REMOVE_AFTER_MS = 3000;
  * @returns {Function}
  */
 MiddlewareRegistry.register(store => next => action => {
+    // `Riff` requires a hidden `Transcriber` participant in the meeting room always to collect
+    // utterance data. Hence we invite a `Transcriber` at the start of a conference.
+    // Refer to changes to `_conferenceJoined` in react/features/conference/middleware.js.
+    //
+    // Commented out `_requestingSubtitlesToggled` and `_requestingSubtitlesSet` calls below to
+    // avoid `Transcriber` invite or remove request calls to Jicofo & Jigasi during a meeting.
+    // This change will not affect existing functionality to `Start Subtitles` or `Stop Subtitles`
+    // as the Transcriber is now always present.
     switch (action.type) {
     case ENDPOINT_MESSAGE_RECEIVED:
         return _endpointMessageReceived(store, next, action);
 
     case TOGGLE_REQUESTING_SUBTITLES:
-        _requestingSubtitlesToggled(store);
+        // _requestingSubtitlesToggled(store);
         break;
     case SET_REQUESTING_SUBTITLES:
-        _requestingSubtitlesSet(store, action.enabled);
+        // _requestingSubtitlesSet(store, action.enabled);
         break;
     }
 
@@ -163,6 +171,10 @@ function _endpointMessageReceived({ dispatch, getState }, next, action) {
     return next(action);
 }
 
+// Riff change that _requestingSubtitlesToggled & _requestingSubtitlesSet are
+// not called, we want to keep the functions around to make patching updates
+// easier. Therefore disabling the lint error.
+/* eslint-disable no-unused-vars */
 /**
  * Toggle the local property 'requestingTranscription'. This will cause Jicofo
  * and Jigasi to decide whether the transcriber needs to be in the room.
@@ -198,6 +210,7 @@ function _requestingSubtitlesSet({ getState }, enabled: boolean) {
         P_NAME_REQUESTING_TRANSCRIPTION,
         enabled);
 }
+/* eslint-enable no-unused-vars */
 
 /**
  * Set a timeout on a TranscriptMessage object so it clears itself when it's not


### PR DESCRIPTION
## Description

`Riff` requires a hidden `Transcriber` participant in the meeting room always to collect utterance data. Hence we invite a `Transcriber` at the start of a conference. Refer to changes to `_conferenceJoined` in `react/features/conference/middleware.js`. 

Commented `_requestingSubtitlesToggled` and `_requestingSubtitlesSet` calls in `subtitles` `middlewares` in `react/features/subtitles/middleware.js` to avoid `Transcriber` invite or remove request calls to Jicafo & Jigasi during a meeting. This change will not affect existing functionality to `Start Subtitles` or `Stop Subtitles` as the Transcriber is always present.

## Motivation and context

jira-ref: [RA-684](https://esme-learning.atlassian.net/browse/RA-684)

## How has this been tested?
Tested on Sandbox1 in 1:1 meetings and group meetings.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
