### PR TITLE
Add the Riff Local Recording feature to the latest jitsi-meet version 7439

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -93,5 +93,6 @@ $flagsImagePath: "../images/";
 @import 'plan-limit';
 @import 'polls';
 @import 'notifications';
+@import 'riff-styles';
 
 /* Modules END */

--- a/css/riff-styles.scss
+++ b/css/riff-styles.scss
@@ -1,0 +1,4 @@
+.local-rec-label {
+    background: #E04757 !important;
+    margin-right: 4px !important;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,7 @@
         "clipboard-copy": "4.0.1",
         "clsx": "1.1.1",
         "dropbox": "10.7.0",
+        "fix-webm-duration": "^1.0.5",
         "focus-visible": "5.1.0",
         "grapheme-splitter": "1.0.4",
         "i18n-iso-countries": "6.8.0",
@@ -11274,6 +11275,11 @@
       "dependencies": {
         "micromatch": "^4.0.2"
       }
+    },
+    "node_modules/fix-webm-duration": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fix-webm-duration/-/fix-webm-duration-1.0.5.tgz",
+      "integrity": "sha512-b6oula3OfSknx0aWoLsxvp4DVIYbwsf+UAkr6EDAK3iuMYk/OSNKzmeSI61GXK0MmFTEuzle19BPvTxMIKjkZg=="
     },
     "node_modules/flat-cache": {
       "version": "3.0.4",
@@ -30948,6 +30954,11 @@
       "requires": {
         "micromatch": "^4.0.2"
       }
+    },
+    "fix-webm-duration": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/fix-webm-duration/-/fix-webm-duration-1.0.5.tgz",
+      "integrity": "sha512-b6oula3OfSknx0aWoLsxvp4DVIYbwsf+UAkr6EDAK3iuMYk/OSNKzmeSI61GXK0MmFTEuzle19BPvTxMIKjkZg=="
     },
     "flat-cache": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "clipboard-copy": "4.0.1",
     "clsx": "1.1.1",
     "dropbox": "10.7.0",
+    "fix-webm-duration": "^1.0.5",
     "focus-visible": "5.1.0",
     "grapheme-splitter": "1.0.4",
     "i18n-iso-countries": "6.8.0",

--- a/react/features/app/middlewares.any.js
+++ b/react/features/app/middlewares.any.js
@@ -42,6 +42,7 @@ import '../recent-list/middleware';
 import '../recording/middleware';
 import '../rejoin/middleware';
 import '../riff-integration/middleware';
+import '../riff-local-recording/middleware';
 import '../room-lock/middleware';
 import '../rtcstats/middleware';
 import '../speaker-stats/middleware';

--- a/react/features/app/reducers.any.js
+++ b/react/features/app/reducers.any.js
@@ -47,6 +47,7 @@ import '../reactions/reducer';
 import '../recent-list/reducer';
 import '../recording/reducer';
 import '../riff-integration/reducer';
+import '../riff-local-recording/reducer';
 import '../settings/reducer';
 import '../speaker-stats/reducer';
 import '../subtitles/reducer';

--- a/react/features/conference/components/constants.js
+++ b/react/features/conference/components/constants.js
@@ -1,5 +1,5 @@
 export const CONFERENCE_INFO = {
-    alwaysVisible: [ 'recording', 'raised-hands-count' ],
+    alwaysVisible: [ 'recording', 'localrecording', 'raised-hands-count' ],
     autoHide: [
         'highlight-moment',
         'subject',

--- a/react/features/conference/components/web/ConferenceInfo.js
+++ b/react/features/conference/components/web/ConferenceInfo.js
@@ -9,6 +9,7 @@ import { connect } from '../../../base/redux';
 import { E2EELabel } from '../../../e2ee';
 import { RecordingLabel } from '../../../recording';
 import HighlightButton from '../../../recording/components/Recording/web/HighlightButton';
+import { LocalRecordingLabel } from '../../../riff-local-recording';
 import { isToolboxVisible } from '../../../toolbox/functions.web';
 import { TranscribingLabel } from '../../../transcribing';
 import { VideoQualityLabel } from '../../../video-quality';
@@ -82,6 +83,10 @@ const COMPONENTS = [
     {
         Component: InsecureRoomNameLabel,
         id: 'insecure-room'
+    },
+    {
+        Component: LocalRecordingLabel,
+        id: 'localrecording'
     }
 ];
 

--- a/react/features/riff-local-recording/actionTypes.js
+++ b/react/features/riff-local-recording/actionTypes.js
@@ -1,0 +1,28 @@
+/**
+ * Action to signal that the local client has started to perform recording,
+ * (as in: {@code RecordingAdapter} is actively collecting audio data).
+ *
+ * @type LOCAL_RECORDING_ENGAGED,
+ */
+export const LOCAL_RECORDING_ENGAGED = 'LOCAL_RECORDING_ENGAGED';
+
+/**
+ * Action to signal that the local client has stopped recording,
+ * (as in: {@code RecordingAdapter} is no longer collecting audio data).
+ *
+ * @type LOCAL_RECORDING_UNENGAGED
+ * {
+ *     type: LOCAL_RECORDING_UNENGAGED
+ * }
+ */
+export const LOCAL_RECORDING_UNENGAGED = 'LOCAL_RECORDING_UNENGAGED';
+
+/**
+ * Action to set stats from all clients.
+ *
+ * @type LOCAL_RECORDING_STATS,
+ */
+export const LOCAL_RECORDING_STATS = 'LOCAL_RECORDING_STATS';
+
+export const LOCAL_RECORDING_SET_SHARED_VIDEO_ID = 'LOCAL_RECORDING_SET_SHARED_VIDEO_ID';
+

--- a/react/features/riff-local-recording/actions.js
+++ b/react/features/riff-local-recording/actions.js
@@ -1,0 +1,72 @@
+/* @flow */
+
+import {
+    LOCAL_RECORDING_ENGAGED,
+    LOCAL_RECORDING_UNENGAGED,
+    LOCAL_RECORDING_STATS,
+    LOCAL_RECORDING_SET_SHARED_VIDEO_ID
+} from './actionTypes';
+
+// The following two actions signal state changes in local recording engagement.
+// In other words, the events of the local WebWorker / MediaRecorder starting to
+// record and finishing recording.
+// Note that this is not the event fired when the users tries to start the
+// recording in the UI.
+
+/**
+ * Signals that local recording has been engaged.
+ *
+ * @returns {{
+ *     type: LOCAL_RECORDING_ENGAGED,
+ * }}
+ */
+export function localRecordingEngaged() {
+    return {
+        type: LOCAL_RECORDING_ENGAGED
+    };
+}
+
+/**
+ * Signals that local recording has finished.
+ *
+ * @returns {{
+ *     type: LOCAL_RECORDING_UNENGAGED
+ * }}
+ */
+export function localRecordingUnengaged() {
+    return {
+        type: LOCAL_RECORDING_UNENGAGED
+    };
+}
+
+/**
+ * Local recording stats.
+ *
+ * @param {*} stats - The stats object.
+ * @returns {{
+ *     type: LOCAL_RECORDING_STATS,
+ *     stats: Object
+ * }}
+ */
+export function localRecordingStats(stats) {
+    return {
+        type: LOCAL_RECORDING_STATS,
+        stats
+    };
+}
+
+/**
+ * YouTube video id for add/remove user microphone with local recording.
+ *
+ * @param {string} id - The shared YouTube video id.
+ * @returns {{
+    *     type: LOCAL_RECORDING_SET_SHARED_VIDEO_ID,
+    *     id: string
+    * }}
+    */
+export function setSharedVideoId(id) {
+    return {
+        type: LOCAL_RECORDING_SET_SHARED_VIDEO_ID,
+        id
+    };
+}

--- a/react/features/riff-local-recording/components/DownloadInfoDialog.js
+++ b/react/features/riff-local-recording/components/DownloadInfoDialog.js
@@ -1,0 +1,100 @@
+/* eslint-disable react-native/no-inline-styles */
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable require-jsdoc */
+
+import { Typography } from '@material-ui/core';
+import DialogContent from '@material-ui/core/DialogContent';
+import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
+import React, { useState, useEffect } from 'react';
+
+import { hideDialog, Dialog } from '../../base/dialog';
+import { connect } from '../../base/redux';
+import { recordingController } from '../controller/RecordingController';
+
+const useStyles = makeStyles(() => {
+    return {
+        root: {
+            width: '100%',
+            maxWidth: 360,
+            backgroundColor: 'none'
+        },
+        paper: {
+            width: '80%',
+            maxHeight: 435
+        },
+        info: {
+            fontSize: '0.8rem'
+        },
+        autoRecording: {
+            marginTop: '1rem',
+            fontSize: '0.8rem',
+            fontWeight: 'bold'
+        }
+    };
+});
+
+function DownloadInfoDialog({ onClose }) {
+    const [ startAutoDownloading, setStartAutoDownloading ] = useState(false);
+    const [ counter, setCounter ] = useState(15);
+
+    const classes = useStyles();
+    const onSubmit = () => {
+        recordingController.onMemoryExceededDownload();
+        onClose();
+    };
+
+    useEffect(() => {
+        const timer = counter > 0
+        && setInterval(() => {
+            if (counter === 10) {
+                setStartAutoDownloading(true);
+            }
+            setCounter(counter - 1);
+        }, 1000);
+
+        if (counter === 0) {
+            onSubmit();
+        }
+
+        return () => clearInterval(timer);
+    }, [ counter ]);
+
+    return (
+        <Dialog
+            className = { classes.root }
+            isModal = { true }
+            maxWidth = 'md'
+            okKey = 'Download recording'
+            onSubmit = { onSubmit }
+            open = { true }>
+            <Typography style = {{ fontSize: '1.5rem' }}>Local Recording</Typography>
+            <DialogContent dividers = { true }>
+                <Typography className = { classes.info }>
+                    Memory limit exceeded. To download the recording file click on download recording.
+                </Typography>
+                {startAutoDownloading
+                && <Typography className = { classes.autoRecording }>
+                    {`Download will start in ${counter} seconds`}
+                </Typography>
+                }
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+DownloadInfoDialog.propTypes = {
+    onClose: PropTypes.func
+};
+
+const mapStateToProps = () => {
+    return { };
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        onClose: () => dispatch(hideDialog())
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(DownloadInfoDialog);

--- a/react/features/riff-local-recording/components/LocalRecordingButton.js
+++ b/react/features/riff-local-recording/components/LocalRecordingButton.js
@@ -1,0 +1,56 @@
+/* eslint-disable react/jsx-no-bind */
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { toggleDialog } from '../../base/dialog/actions';
+import { isMobileBrowser } from '../../base/environment/utils';
+import { IconRec } from '../../base/icons';
+import { connect } from '../../base/redux';
+import ToolboxItem from '../../base/toolbox/components/ToolboxItem.web';
+import { recordingController } from '../controller/RecordingController';
+
+import LocalRecordingDialog from './LocalRecordingDialog';
+
+const LocalRecordingButton = ({
+    toggleLocalRecordingDialog,
+    showLabel,
+    isEngagedLocally
+}) => {
+    const doToggleLocalRecordingDialog = () => toggleLocalRecordingDialog();
+    const doStopLocalRecording = () => recordingController.stopRecording();
+
+    const isMobile = isMobileBrowser();
+
+    if (isMobile) {
+        return null;
+    }
+
+    return (
+        <ToolboxItem
+            accessibilityLabel = 'Local Recording'
+            icon = { IconRec }
+            label = { `${isEngagedLocally ? 'Stop' : 'Start'} Local Recording` }
+            onClick = { isEngagedLocally ? doStopLocalRecording : doToggleLocalRecordingDialog }
+            showLabel = { showLabel } />
+    );
+};
+
+LocalRecordingButton.propTypes = {
+    isEngagedLocally: PropTypes.bool,
+    showLabel: PropTypes.bool,
+    toggleLocalRecordingDialog: PropTypes.func
+};
+
+const mapStateToProps = state => {
+    return {
+        isEngagedLocally: state['features/riff-local-recording'].stats?.isRecording
+    };
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        toggleLocalRecordingDialog: () => dispatch(toggleDialog(LocalRecordingDialog))
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LocalRecordingButton);

--- a/react/features/riff-local-recording/components/LocalRecordingDialog.js
+++ b/react/features/riff-local-recording/components/LocalRecordingDialog.js
@@ -1,0 +1,93 @@
+/* eslint-disable react-native/no-inline-styles */
+/* eslint-disable react/jsx-no-bind */
+/* eslint-disable require-jsdoc */
+
+import { Typography, List, ListItem, ListItemText } from '@material-ui/core';
+import DialogContent from '@material-ui/core/DialogContent';
+import { makeStyles } from '@material-ui/core/styles';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { hideDialog, Dialog } from '../../base/dialog';
+import { connect } from '../../base/redux';
+import { recordingController } from '../controller/RecordingController';
+
+const useStyles = makeStyles(() => {
+    return {
+        root: {
+            width: '100%',
+            maxWidth: 360,
+            backgroundColor: 'none'
+        },
+        paper: {
+            width: '80%',
+            maxHeight: 435
+        }
+    };
+});
+
+const recordingSteps = [ 'To start recording click on start recording',
+    'Select screen type to start recording',
+    'Click on share button to confirm recording'
+];
+
+function LocalRecordingDialog({ onClose }) {
+
+    const classes = useStyles();
+
+    const handleCancel = () => {
+        onClose();
+    };
+
+    const onSubmit = () => {
+        recordingController.startRecording();
+        handleCancel();
+    };
+
+    const renderControls = (
+        <>
+            <Typography>Follow the below steps to do screen recording:</Typography>
+            <List>
+                {recordingSteps.map((el, i) => (
+                    <ListItem
+                        dense = { true }
+                        disableGutters = { true }
+                        key = { i }>
+                        <ListItemText
+                            primary = { `*${el}` } />
+                    </ListItem>
+                ))}
+            </List>
+        </>);
+
+    return (
+        <Dialog
+            cancelKey = { 'dialog.close' }
+            className = { classes.root }
+            maxWidth = 'md'
+            okKey = 'Start Recording'
+            onCancel = { handleCancel }
+            onSubmit = { onSubmit }>
+            <Typography style = {{ fontSize: '1.5rem' }}>Local Recording</Typography>
+            <DialogContent dividers = { true }>
+                {renderControls}
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+LocalRecordingDialog.propTypes = {
+    onClose: PropTypes.func
+};
+
+const mapStateToProps = () => {
+    return { };
+};
+
+const mapDispatchToProps = dispatch => {
+    return {
+        onClose: () => dispatch(hideDialog())
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(LocalRecordingDialog);

--- a/react/features/riff-local-recording/components/LocalRecordingLabel.js
+++ b/react/features/riff-local-recording/components/LocalRecordingLabel.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { Label } from '../../base/label/index';
+import { connect } from '../../base/redux';
+import { Tooltip } from '../../base/tooltip';
+
+const LocalRecordingLabel = ({ isEngaged }) => {
+    if (!isEngaged) {
+        return null;
+    }
+
+    return (
+        <Tooltip
+            content = { 'Local recording is engaged' }
+            position = { 'bottom' }>
+            <Label
+                className = 'local-rec-label'
+                text = { 'REC' } />
+        </Tooltip>
+    );
+};
+
+LocalRecordingLabel.propTypes = {
+    isEngaged: PropTypes.bool
+};
+
+const mapStateToProps = state => {
+    return {
+        isEngaged: state['features/riff-local-recording'].isEngaged
+    };
+};
+
+export default connect(mapStateToProps)(LocalRecordingLabel);

--- a/react/features/riff-local-recording/components/WebmAdapter.js
+++ b/react/features/riff-local-recording/components/WebmAdapter.js
@@ -1,0 +1,383 @@
+/* eslint-disable require-jsdoc */
+
+import fixWebmDuration from 'fix-webm-duration';
+
+import {
+    MEDIARECORDER_TIMESLICE,
+    MEDIARECORDER_MAX_SIZE
+} from '../constants';
+import { recordingController } from '../controller/';
+import {
+    getCombinedStream,
+    addNewAudioStream,
+    removeAudioStream,
+    cleanupAudioContext
+} from '../helpers';
+import logger from '../logger';
+import { RecordingAdapter } from '../recording';
+
+/**
+ * Recording adapter that uses {@code MediaRecorder}.
+ */
+export default class WebmAdapter extends RecordingAdapter {
+
+    /**
+     *
+     * Instance of MediaRecorder.
+     *
+     * @private
+     */
+    _mediaRecorder = null;
+
+    /**
+     *
+     * Initialization promise.
+     *
+     * @private
+     */
+    _initPromise = null;
+
+    /**
+     *
+     * The recorded media file.
+     *
+     * @private
+     */
+    _recordedData = [];
+
+    /**
+     *
+     * The recorded stream.
+     *
+     * @private
+     */
+    _recorderStream = null;
+
+    /**
+     *
+     * The {@code JitsiConference} instance.
+     *
+     * @private
+     */
+    _conference = null;
+
+    /**
+     *
+     * Instance of MediaRecorder.
+     *
+     * @private
+     */
+    _newMediaRecorder = null;
+
+    /**
+     *
+     * Prevents initialization new MediadRecorder from happening multiple times.
+     */
+    _isCalled = false;
+
+    _participantAudioStreams = [];
+
+    /**
+     *
+     * Time when recording started.
+     */
+    _startTime = null;
+
+    /**
+     *
+     * Implements {@link RecordingAdapter#start()}.
+     *
+     * @inheritdoc
+     */
+    start(micDeviceId, conference) {
+        this._conference = conference;
+
+        if (!this._initPromise) {
+            this._initPromise = this._initialize(micDeviceId);
+        }
+
+        return this._initPromise.then(() =>
+            new Promise(resolve => {
+                this._mediaRecorder.start(MEDIARECORDER_TIMESLICE);
+                this._startTime = new Date();
+                resolve();
+            })
+        );
+    }
+
+    /**
+     * Implements {@link RecordingAdapter#stop()}.
+     *
+     * @inheritdoc
+     */
+    stop() {
+        return new Promise(
+            resolve => {
+                // eslint-disable-next-line no-negated-condition
+                if (this._mediaRecorder.state !== 'inactive') {
+                    this._mediaRecorder.stop(this._stopStreamTracks());
+                    this._mediaRecorder.onstop = () => resolve();
+                    this._mediaRecorder = null;
+                } else {
+                    this._stopStreamTracks();
+                    this._mediaRecorder = null;
+                    resolve();
+                }
+            }
+        );
+    }
+
+    /**
+     * Returns the remote participant id and audio stream.
+     *
+     * @private
+     * @param {Object} participant - The participant object.
+     * @returns {({Object}|undefined)} - The object with participant id and audio stream.
+     */
+    _getAudioParticipantStream(participant) {
+        if (participant._tracks?.length) {
+            return {
+                id: participant._id,
+                stream: participant._tracks.find(t => t.type === 'audio')?.stream
+            };
+        }
+    }
+
+    /**
+     * Returns array of remote participants id and their audio stream.
+     *
+     * @private
+     *
+     * @returns {(Object[])} - List of remote participants id and their audio stream.
+     */
+    _getAudioParticipantsStream() {
+        const participantsAudioStreamArray = this._conference.getParticipants()
+          .map(participant => this._getAudioParticipantStream(participant))
+          .filter(participant => participant && participant.stream);
+
+        return participantsAudioStreamArray;
+    }
+
+    /**
+     * Implements {@link RecordingAdapter#exportRecordedData()}.
+     *
+     * @inheritdoc
+     */
+    exportRecordedData() {
+        if (this._recordedData.length) {
+            const blobData = new Blob(this._recordedData, { type: 'video/webm' });
+
+            const duration = new Date() - this._startTime;
+
+            return fixWebmDuration(blobData, duration, { logger: false }).then(fixedBlobData => Promise.resolve({
+                data: fixedBlobData,
+                format: 'webm'
+            }));
+
+        }
+
+        return Promise.reject('No media data recorded.');
+    }
+
+    /**
+     * Implements {@link RecordingAdapter#setMuted()}.
+     *
+     * @inheritdoc
+     */
+    setMuted(muted) {
+        const shouldEnable = !muted;
+
+        this._initialize();
+
+        if (!this._stream) {
+            return Promise.resolve();
+        }
+
+        const track = this._stream.getAudioTracks()[0];
+
+        if (!track) {
+            logger.error('Cannot mute/unmute. Track not found!');
+
+            return Promise.resolve();
+        }
+
+        if (track.enabled !== shouldEnable) {
+            track.enabled = shouldEnable;
+            logger.log(muted ? 'Mute' : 'Unmute');
+        }
+
+        return Promise.resolve();
+    }
+
+    /**
+     * Add new audio stream to AudioContext.
+     *
+     * @param {MediaStream} newAudioStream - The new participant audio stream.
+     * @returns {void}
+     */
+
+    addNewParticipantAudioStream(newAudioStream, id) {
+        if (newAudioStream.getAudioTracks().length) {
+            addNewAudioStream(newAudioStream, id);
+        }
+    }
+
+    /**
+     * Initialize the adapter.
+     *
+     * @private
+     * @param {string} micDeviceId - The current microphone device ID.
+     * @returns {Promise}
+     */
+    _initialize(micDeviceId) {
+
+        if (this._mediaRecorder) {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve, error) => {
+            this._getAudioStream(micDeviceId)
+            .then(async userAudioStream => {
+                const participatsStream = this._getAudioParticipantsStream() || [];
+                const allParticipatsAudioStreams = participatsStream.concat({ id: 'local',
+                    stream: userAudioStream });
+
+                this._participantAudioStreams = allParticipatsAudioStreams;
+
+                getCombinedStream(allParticipatsAudioStreams)
+                .then(mediaStream => {
+                    this._stream = userAudioStream;
+                    this._initializeCurrentMediaRecoder(mediaStream);
+                    this._recorderStream = mediaStream;
+
+                    resolve();
+
+                    this._recorderStream.getVideoTracks()[0].onended = () => {
+                        logger.log('Capture stream inactive');
+
+                        return recordingController.stopRecording();
+                    };
+                })
+                .catch(err => {
+                    logger.error(`Error calling getUserMedia(): ${err}`);
+                    error();
+                });
+            })
+            .catch(err => {
+                logger.error(`Error calling getUserMedia(): ${err}`);
+                error();
+            });
+        });
+    }
+
+    /**
+     * Initialize the current MediaRecorder.
+     *
+     * @private
+     * @param {MediaStream} stream - The current stream.
+     * @returns {void}
+     */
+    _initializeCurrentMediaRecoder(stream) {
+        this._mediaRecorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
+        this._mediaRecorder.ondataavailable = e => this._onMediaDataAvailable(e.data);
+    }
+
+    /**
+     * Initialize the new MediaRecorder. To continue recording with current stream.
+     *
+     * @private
+     * @param {MediaStream} stream - The current stream.
+     * @returns {void}
+     */
+    _initializeNewMediaRecoder(stream) {
+        this._newMediaRecorder = new MediaRecorder(stream, { mimeType: 'video/webm' });
+        this._newMediaRecorder.ondataavailable = e => this._onMediaDataAvailable(e.data);
+    }
+
+
+    /**
+     * Stop MediaRecorder in case memory limit exceeded.
+     *
+     * @returns {void}
+     */
+    handleMemoryExceededStop() {
+        return new Promise(
+            resolve => {
+                this._mediaRecorder.onstop = () => resolve();
+                this._mediaRecorder.stop();
+            }
+        );
+    }
+
+    /**
+     * Restarts MediaRecorder with the same stream.
+     *
+     * @returns {void}
+     */
+    onRecordingRestart() {
+        this._mediaRecorder = this._newMediaRecorder;
+        this._mediaRecorder.start(MEDIARECORDER_TIMESLICE);
+        this._mediaRecorder.requestData();
+        this._newMediaRecorder = null;
+        this._recordedData = [];
+        this._isCalled = false;
+        this._startTime = new Date();
+    }
+
+
+    /**
+     * Callback for checking/storing the data.
+     *
+     * @private
+     * @param {Blob} data - Encoded data.
+     * @returns {void}
+     */
+    _onMediaDataAvailable(data) {
+        const currentRecordingBlob = new Blob(this._recordedData, { type: 'video/webm' });
+        const sizeInMB = currentRecordingBlob.size / (1024 * 1024);
+
+        this._saveMediaData(data);
+        if (sizeInMB >= MEDIARECORDER_MAX_SIZE
+            && this._mediaRecorder
+            && this._mediaRecorder.state === 'recording'
+            && !this._isCalled) {
+
+            if (recordingController._onMemoryExceeded) {
+                recordingController._onMemoryExceeded(true);
+            }
+            this._initializeNewMediaRecoder(this._recorderStream);
+            this._isCalled = true;
+        }
+    }
+
+    _stopStreamTracks() {
+        if (this._mediaRecorder) {
+            this._mediaRecorder.stream.getTracks().forEach(track => track.stop());
+        }
+        cleanupAudioContext();
+    }
+
+    /**
+     * Function for storing the data.
+     *
+     * @private
+     * @param {Blob} data - Encoded data.
+     * @returns {void}
+     */
+    _saveMediaData(data) {
+        this._recordedData.push(data);
+    }
+
+    /**
+     * Implements {@link RecordingAdapter#setMicDevice()}.
+     *
+     * @inheritdoc
+     */
+    setMicDevice(micDeviceId) {
+        return this._replaceMic(micDeviceId);
+    }
+
+    removeAudioStreamsById(id) {
+        removeAudioStream(id);
+    }
+}

--- a/react/features/riff-local-recording/components/index.js
+++ b/react/features/riff-local-recording/components/index.js
@@ -1,0 +1,3 @@
+export { default as LocalRecordingButton } from './LocalRecordingButton';
+export { default as LocalRecordingLabel } from './LocalRecordingLabel';
+export { default as LocalRecordingDialog } from './LocalRecordingDialog';

--- a/react/features/riff-local-recording/constants.js
+++ b/react/features/riff-local-recording/constants.js
@@ -1,0 +1,64 @@
+/**
+ * XMPP command for signaling the start of local recording to all clients.
+ * Should be sent by the moderator only.
+ */
+const COMMAND_START = 'localRecStart';
+
+/**
+ * XMPP command for signaling the stop of local recording to all clients.
+ * Should be sent by the moderator only.
+ */
+const COMMAND_STOP = 'localRecStop';
+
+/**
+ * One-time command used to trigger the moderator to resend the commands.
+ * This is a workaround for newly-joined clients to receive remote presence.
+ */
+const COMMAND_PING = 'localRecPing';
+
+/**
+ * One-time command sent upon receiving a {@code COMMAND_PING}.
+ * Only the moderator sends this command.
+ * This command does not carry any information itself, but rather forces the
+ * XMPP server to resend the remote presence.
+ */
+const COMMAND_PONG = 'localRecPong';
+
+/**
+ * Participant property key for local recording stats.
+ */
+const PROPERTY_STATS = 'localRecStats';
+
+/**
+ * Supported recording formats.
+ */
+const RECORDING_FORMATS = new Set([ 'webm' ]);
+
+/**
+ * Default recording format.
+ */
+const DEFAULT_RECORDING_FORMAT = 'webm';
+
+/**
+ * The argument slices the recording into chunks, calling dataavailable every defined seconds.
+ */
+const MEDIARECORDER_TIMESLICE = 180000;
+
+/**
+ * Defined max size for blob(MB).
+ */
+const MEDIARECORDER_MAX_SIZE = 950;
+
+
+export {
+    COMMAND_START,
+    COMMAND_STOP,
+    COMMAND_PING,
+    COMMAND_PONG,
+    PROPERTY_STATS,
+    RECORDING_FORMATS,
+    DEFAULT_RECORDING_FORMAT,
+    MEDIARECORDER_TIMESLICE,
+    MEDIARECORDER_MAX_SIZE
+};
+

--- a/react/features/riff-local-recording/controller/RecordingController.js
+++ b/react/features/riff-local-recording/controller/RecordingController.js
@@ -1,0 +1,766 @@
+/* @flow */
+
+/* eslint-disable no-unused-vars */
+/* eslint-disable flowtype/no-types-missing-file-annotation */
+
+import WebmAdapter from '../components/WebmAdapter';
+import {
+    COMMAND_START,
+    COMMAND_STOP,
+    COMMAND_PING,
+    COMMAND_PONG,
+    PROPERTY_STATS,
+    DEFAULT_RECORDING_FORMAT
+} from '../constants';
+import logger from '../logger';
+import { downloadBlob } from '../recording';
+import { sessionManager } from '../session';
+
+/**
+ * States of the {@code LocalRecordingController}.
+ */
+const ControllerState = Object.freeze({
+    /**
+     * Idle (not recording).
+     */
+    IDLE: Symbol('IDLE'),
+
+    /**
+     * Starting.
+     */
+    STARTING: Symbol('STARTING'),
+
+    /**
+     * Engaged (recording).
+     */
+    RECORDING: Symbol('RECORDING'),
+
+    /**
+     * Stopping."flowtype/no-types-missing-file-annotation": 0.
+     */
+    STOPPING: Symbol('STOPPING'),
+
+    /**
+     * Failed, due to error during starting / stopping process.
+     */
+    FAILED: Symbol('FAILED')
+});
+
+/**
+ * Type of the stats reported by each participant (client).
+ */
+type LocalRecordingStats = {
+
+    /**
+     * Current local recording session token used by the participant.
+     */
+    currentSessionToken: number,
+
+    /**
+     * Whether local recording is engaged on the participant's device.
+     */
+    isRecording: boolean
+}
+
+/**
+ *  The component responsible for the local recording.
+ */
+class LocalRecordingController {
+    /**
+     * For each recording session, there is a separate @{code RecordingAdapter}
+     * instance so that encoded bits from the previous sessions can still be
+     * retrieved after they ended.
+     *
+     * @private
+     */
+    _adapter = {};
+
+    /**
+     * The {@code JitsiConference} instance.
+     *
+     * @private
+     */
+    _conference: * = null;
+
+    /**
+     * Current recording session token.
+     *
+     * @private
+     */
+    _currentSessionToken: number = -1;
+
+    /**
+     * Current state of {@code LocalRecordingController}.
+     *
+     * @private
+     */
+    _state = ControllerState.IDLE;
+
+    /**
+     * Whether or not the audio is muted in the UI. This is stored as internal
+     * state of {@code LocalRecordingController} because we might have recording
+     * sessions that start muted.
+     */
+    _isMuted = false;
+
+    /**
+     * The ID of the active microphone.
+     *
+     * @private
+     */
+    _micDeviceId = 'default';
+
+    /**
+     * Current recording format.
+     *
+     * @private
+     */
+    _format = DEFAULT_RECORDING_FORMAT;
+
+    /**
+     * Whether or not the {@code LocalRecordingController} has registered for
+     * XMPP events. Prevents initialization from happening multiple times.
+     *
+     * @private
+     */
+    _registered = false;
+
+    /**
+     * Current room name.
+     *
+     * @private
+     */
+    _meetingName = '';
+
+    /**
+     * Recording part of same session.
+     *
+     * @private
+     */
+    _recordingPart = 0;
+
+    /**
+     * FIXME: callback function for the {@code LocalRecordingController} to notify
+     * UI it wants to display a notice. Keeps {@code LocalRecordingController}
+     * decoupled from UI.
+     */
+    _onNotify: ?(messageKey: string, messageParams?: Object) => void;
+
+    /**
+     * FIXME: callback function for the {@code LocalRecordingController} to notify
+     * UI it wants to display a warning. Keeps {@code LocalRecordingController}
+     * decoupled from UI.
+     */
+    _onWarning: ?(messageKey: string, messageParams?: Object) => void;
+
+    /**
+     * FIXME: callback function for the {@code LocalRecordingController} to notify
+     * UI that the local recording state has changed.
+     */
+    _onStateChanged: ?(boolean) => void;
+
+    /**
+     * Saves in the redux store user local recording state.
+     */
+    _onStatusUpdated: ?(boolean) => void;
+
+    /**
+     * FIXME: callback function for the {@code LocalRecordingController} to notify
+     * UI it wants to display a dialog. Keeps {@code LocalRecordingController}
+     * decoupled from UI.
+     */
+    _onMemoryExceeded: ?(boolean) => void;
+
+    /**
+     * Constructor.
+     *
+     * @returns {void}
+     */
+    constructor() {
+        this.registerEvents = this.registerEvents.bind(this);
+        this.getParticipantsStats = this.getParticipantsStats.bind(this);
+        this._onStartCommand = this._onStartCommand.bind(this);
+        this._onStopCommand = this._onStopCommand.bind(this);
+        this._onPingCommand = this._onPingCommand.bind(this);
+        this._doStartRecording = this._doStartRecording.bind(this);
+        this._doStopRecording = this._doStopRecording.bind(this);
+        this._updateStats = this._updateStats.bind(this);
+        this._switchToNewSession = this._switchToNewSession.bind(this);
+
+        this._startRecordingNotificationHandler = this._startRecordingNotificationHandler.bind(this);
+        this._onStartNotification = this._onStartNotification.bind(this);
+        this._stopRecordingNotificationHandler = this._stopRecordingNotificationHandler.bind(this);
+        this._onStopNotification = this._onStopNotification.bind(this);
+        this.onMemoryExceededDownload = this.onMemoryExceededDownload.bind(this);
+        this.onNewParticipantAudioStreamAdded = this.onNewParticipantAudioStreamAdded.bind(this);
+    }
+
+    registerEvents: (*) => void;
+
+    /**
+     * Registers listeners for XMPP events.
+     *
+     * @param {JitsiConference} conference - A {@code JitsiConference} instance.
+     * @param {string} meetingName - Conference room name.
+     * @returns {void}
+     */
+    registerEvents(conference: Object, meetingName: string) {
+        if (!this._registered) {
+            this._conference = conference;
+            this._meetingName = meetingName;
+            if (this._conference) {
+                this._conference
+                    .addCommandListener(COMMAND_STOP, this._onStopNotification);
+                this._conference
+                    .addCommandListener(COMMAND_START, this._onStartNotification);
+                this._conference
+                    .addCommandListener(COMMAND_PING, this._onPingCommand);
+                this._registered = true;
+            }
+            if (!this._conference.isModerator()) {
+                this._conference.sendCommandOnce(COMMAND_PING, {});
+            }
+        }
+    }
+
+    /**
+     * Sets the event handler for {@code onStateChanged}.
+     *
+     * @param {Function} delegate - The event handler.
+     * @returns {void}
+     */
+    set onStateChanged(delegate: Function) {
+        this._onStateChanged = delegate;
+    }
+
+    /**
+     * Sets the event handler for {@code onStatusUpdated}.
+     *
+     * @param {Function} delegate - The event handler.
+     * @returns {void}
+     */
+    set onStatusUpdated(delegate: Function) {
+        this._onStatusUpdated = delegate;
+    }
+
+    /**
+     * Sets the event handler for {@code onNotify}.
+     *
+     * @param {Function} delegate - The event handler.
+     * @returns {void}
+     */
+    set onNotify(delegate: Function) {
+        this._onNotify = delegate;
+    }
+
+    /**
+     * Sets the event handler for {@code onWarning}.
+     *
+     * @param {Function} delegate - The event handler.
+     * @returns {void}
+     */
+    set onWarning(delegate: Function) {
+        this._onWarning = delegate;
+    }
+
+    /**
+     * Sets the event handler for {@code onMemoryExceeded}.
+     *
+     * @param {Function} delegate - The event handler.
+     * @returns {void}
+     */
+    set onMemoryExceeded(delegate: Function) {
+        this._onMemoryExceeded = delegate;
+    }
+
+    /**
+     * Signals the participant to start local recording.
+     *
+     * @returns {void}
+     */
+    startRecording() {
+        this.registerEvents();
+        this._onStartCommand({
+            sessionToken: this._getRandomToken()
+        });
+    }
+
+    /**
+     * Signals the participant to stop local recording.
+     *
+     * @returns {void}
+     */
+    stopRecording() {
+        this._onStopCommand();
+    }
+
+    /**
+     * Triggers the download of recorded data.
+     * Browser only.
+     *
+     * @param {number} sessionToken - The token of the session to download.
+     * @returns {void}
+     */
+    downloadRecordedData(sessionToken: number) {
+        const formattedMeetingName = this._meetingName.replace(/ /g, '_');
+
+        if (this._onMemoryExceeded) {
+            this._onMemoryExceeded(false);
+        }
+
+        if (this._adapter) {
+            this._adapter.exportRecordedData()
+                .then(args => {
+                    const { data, format } = args;
+                    const defineSessionPart = this._recordingPart ? `_${this._recordingPart}` : '';
+
+                    const filename = `session_${sessionToken}${defineSessionPart
+                    }_${formattedMeetingName}.${format}`;
+
+                    downloadBlob(data, filename);
+                })
+                .catch(error => {
+                    logger.error('Failed to download media for'
+                        + ` session ${sessionToken}. Error: ${error}`);
+                });
+        } else {
+            logger.error(`Invalid session token for download ${sessionToken}`);
+        }
+    }
+
+    /**
+     * Changes the current microphone.
+     *
+     * @param {string} micDeviceId - The new microphone device ID.
+     * @returns {void}
+     */
+    setMicDevice(micDeviceId: string) {
+        if (micDeviceId !== this._micDeviceId) {
+            this._micDeviceId = String(micDeviceId);
+
+            if (this._state === ControllerState.RECORDING) {
+
+                logger.log('Before switching microphone...');
+                this._adapter
+                    .setMicDevice(this._micDeviceId)
+                    .then(() => {
+                        logger.log('Finished switching microphone.');
+
+                    })
+                    .catch(() => {
+                        logger.error('Failed to switch microphone');
+                    });
+            }
+            logger.log(`Switch microphone to ${this._micDeviceId}`);
+        }
+    }
+
+    /**
+     * Mute or unmute audio. When muted, the ongoing local recording should
+     * produce silence.
+     *
+     * @param {boolean} muted - If the audio should be muted.
+     * @returns {void}
+     */
+    setMuted(muted: boolean) {
+        this._isMuted = Boolean(muted);
+
+        if (this._state === ControllerState.RECORDING) {
+            this._adapter.setMuted(this._isMuted);
+        }
+    }
+
+    /**
+     * Returns the local recording stats.
+     *
+     * @returns {LocalRecordingStats}
+     */
+    getLocalStats(): LocalRecordingStats {
+        return {
+            currentSessionToken: this._currentSessionToken,
+            isRecording: this._state === ControllerState.RECORDING
+        };
+    }
+
+    getParticipantsStats: () => *;
+
+    /**
+     * Returns the remote participants' local recording stats.
+     *
+     * @returns {*}
+     */
+    getParticipantsStats() {
+        const members
+            = this._conference.getParticipants()
+            .map(member => {
+                return {
+                    id: member.getId(),
+                    recordingStats:
+                        JSON.parse(member.getProperty(PROPERTY_STATS) || '{}'),
+                    isSelf: false
+                };
+            });
+
+        // transform into a dictionary for consistent ordering
+        const result = {};
+
+        for (let i = 0; i < members.length; ++i) {
+            result[members[i].id] = members[i];
+        }
+        const localId = this._conference.myUserId();
+
+        result[localId] = {
+            id: localId,
+            recordingStats: this.getLocalStats(),
+            isSelf: true
+        };
+
+        return result;
+    }
+
+    _changeState: (Symbol) => void;
+
+    /**
+     * Changes the current state of {@code LocalRecordingController}.
+     *
+     * @private
+     * @param {Symbol} newState - The new state.
+     * @returns {void}
+     */
+    _changeState(newState: Symbol) {
+        if (this._state !== newState) {
+            logger.log(`state change: ${this._state.toString()} -> `
+                + `${newState.toString()}`);
+            this._state = newState;
+        }
+    }
+
+    _updateStats: () => void;
+
+    /**
+     * Sends out updates about the local recording stats via XMPP.
+     *
+     * @private
+     * @returns {void}
+     */
+    _updateStats() {
+        if (this._conference) {
+            this._conference.setLocalParticipantProperty(PROPERTY_STATS,
+                JSON.stringify(this.getLocalStats()));
+        }
+    }
+
+    _onStartCommand: (*) => void;
+
+    /**
+     * Function for start local recording.
+     *
+     * @private
+     * @param {*} sessionToken - The session token.
+     * @returns {void}
+     */
+    _onStartCommand({ sessionToken }) {
+        if (this._state === ControllerState.IDLE) {
+            this._changeState(ControllerState.STARTING);
+            this._switchToNewSession(sessionToken);
+            this._doStartRecording();
+        } else if (this._state === ControllerState.RECORDING
+            && this._currentSessionToken !== sessionToken) {
+            // There is local recording going on, but not for the same session.
+            // , so we need to restart the recording.
+            this._changeState(ControllerState.STOPPING);
+            this._doStopRecording().then(() => {
+                this._changeState(ControllerState.STARTING);
+                this._switchToNewSession(sessionToken);
+                this._doStartRecording();
+            });
+        }
+    }
+
+    _onStopCommand: (*) => void;
+
+    /**
+     * Function for stop local recording.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onStopCommand() {
+        if (this._state === ControllerState.RECORDING) {
+            this._changeState(ControllerState.STOPPING);
+            this._doStopRecording();
+        }
+    }
+
+    _onPingCommand: () => void;
+
+    /**
+     * Callback function for XMPP event.
+     *
+     * @private
+     * @returns {void}
+     */
+    _onPingCommand() {
+        if (this._conference) {
+            logger.log('Received ping, sending pong.');
+            this._conference.sendCommandOnce(COMMAND_PONG, {});
+        }
+    }
+
+    /**
+     * Generates a token that can be used to distinguish each local recording
+     * session.
+     *
+     * @returns {number}
+     */
+    _getRandomToken() {
+        return Math.floor(Math.random() * 100000000) + 1;
+    }
+
+    _doStartRecording: () => void;
+
+    /**
+     * Starts the recording locally.
+     *
+     * @private
+     * @returns {void}
+     */
+    _doStartRecording() {
+        if (this._state === ControllerState.STARTING) {
+            const delegate = this._adapter;
+
+            this._recordingPart = 0;
+
+            delegate.start(this._micDeviceId, this._conference)
+            .then(() => {
+                this._changeState(ControllerState.RECORDING);
+                sessionManager.beginSegment(this._currentSessionToken);
+                logger.log('Local recording engaged.');
+
+                // if (this._onNotify) {
+                //     this._onNotify('Local recording engaged.');
+                // }
+                this._startRecordingNotificationHandler();
+
+                delegate.setMuted(this._isMuted);
+                this._onStatusUpdated(this.getLocalStats());
+                this._updateStats();
+            })
+            .catch(err => {
+                this._changeState(ControllerState.IDLE);
+                logger.error('Failed to start local recording.', err);
+            });
+        }
+
+    }
+    _startRecordingNotificationHandler: () => void;
+
+    /**
+     * Signals the all participants about local recording engaged .
+     *
+     * @returns {void}
+     */
+    _startRecordingNotificationHandler() {
+        if (this._conference) {
+            this._conference.removeCommand(COMMAND_STOP);
+            this._conference.sendCommand(COMMAND_START, {
+                attributes: { sessionToken: this._currentSessionToken }
+            });
+        } else if (this._onWarning) {
+            this._onWarning('Failed to send command');
+        }
+    }
+
+    _onStartNotification: (*) => void;
+
+    /**
+     * Callback function for XMPP event.
+     *
+     * @private
+     * @param {*} value - The event args.
+     * @returns {void}
+     */
+    _onStartNotification(value) {
+        //  const { sessionToken } = value.attributes;
+
+        if (this._onStateChanged) {
+            this._onStateChanged(true);
+        }
+    }
+
+    _doStopRecording: () => Promise<void>;
+
+    /**
+     * Stops the recording locally.
+     *
+     * @private
+     * @returns {Promise<void>}
+     */
+    _doStopRecording() {
+        if (this._state === ControllerState.STOPPING) {
+            const token = this._currentSessionToken;
+
+            return this._adapter
+                .stop()
+                .then(() => {
+                    this._changeState(ControllerState.IDLE);
+                    sessionManager.endSegment(this._currentSessionToken);
+                    logger.log('Local recording unengaged.');
+                    if (this._recordingPart) {
+                        this._recordingPart = this._recordingPart + 1;
+                    }
+                    this.downloadRecordedData(token);
+
+                    const messageKey = 'Recording session {{token}} finished.';
+                    const messageParams = {
+                        token: this._currentSessionToken
+                    };
+
+                    if (this._onNotify) {
+                        this._onNotify(messageKey, messageParams);
+                    }
+
+                    this._stopRecordingNotificationHandler();
+                    this._onStatusUpdated(this.getLocalStats());
+                    this._updateStats();
+                })
+                .catch(err => {
+                    logger.error('Failed to stop local recording.', err);
+                });
+        }
+
+        /* eslint-disable */
+        return (Promise.resolve(): Promise<void>);
+        // FIXME: better ways to satisfy flow and ESLint at the same time?
+        /* eslint-enable */
+
+    }
+
+    // eslint-disable-next-line flowtype/no-types-missing-file-annotation
+    _stopRecordingNotificationHandler: () => void;
+
+    /**
+     * Signals the all participants about local recording unengaged.
+     *
+     * @returns {void}
+     */
+    _stopRecordingNotificationHandler() {
+        this.registerEvents();
+        if (this._conference) {
+            this._conference.removeCommand(COMMAND_START);
+            this._conference.sendCommand(COMMAND_STOP, {
+                attributes: { sessionToken: this._currentSessionToken }
+            });
+        } else if (this._onWarning) {
+            this._onWarning('Failed to send command');
+        }
+    }
+
+    // eslint-disable-next-line flowtype/no-types-missing-file-annotation
+    _onStopNotification: (*) => void;
+
+    /**
+     * Callback function for XMPP event.
+     *
+     * @private
+     * @param {*} value - The event args.
+     * @returns {void}
+     */
+    _onStopNotification(value) {
+        const { sessionToken } = value.attributes;
+        const isAnyLocalRecordingSessionEngaged = this._checkIsAnyLocalRecordingSessionEngaged(sessionToken);
+
+        if (this._onStateChanged && isAnyLocalRecordingSessionEngaged) {
+            this._onStateChanged(false);
+        }
+    }
+
+    /**
+     * Checks if local recording sessions is engaged after some participant(by currentSessionToken) stopped recording .
+     *
+     * @param {string} currentSessionToken - The current session Token.
+     * @returns {boolean}
+     */
+    _checkIsAnyLocalRecordingSessionEngaged(currentSessionToken) {
+
+        const participantIdLocalRecordingEngaged = Object.values(this.getParticipantsStats())
+            .filter(participant => participant.recordingStats && participant.recordingStats.isRecording);
+        let isAnyLocalRecordingEnabled = true;
+
+        participantIdLocalRecordingEngaged.forEach(participant => {
+            if (participant.recordingStats && participant.recordingStats.currentSessionToken
+                     && participant.recordingStats.currentSessionToken !== parseInt(currentSessionToken, 10)) {
+                isAnyLocalRecordingEnabled = false;
+            }
+        });
+
+        return isAnyLocalRecordingEnabled;
+    }
+
+    /**
+     * Adds new audio stream to AudioContext.
+     *
+     * @param {MediaStream} newStream - The new participant audio stream.
+     * @param {string} id - The new participant id.
+     * @returns {void}
+     */
+    onNewParticipantAudioStreamAdded(newStream, id) {
+        if (this._adapter.addNewParticipantAudioStream) {
+            this._adapter.addNewParticipantAudioStream(newStream, id);
+        }
+    }
+
+    /**
+     * Triggers the download of recorded data in case memory limit exceeded.
+     * Restarts MediaRecorder.
+     *
+     * @returns {void}
+     */
+    onMemoryExceededDownload() {
+        return this._adapter
+            .handleMemoryExceededStop()
+            .then(() => {
+                this.downloadRecordedData(this._currentSessionToken);
+                this._adapter.onRecordingRestart();
+                this._recordingPart = this._recordingPart + 1;
+            })
+            .catch(err => {
+                logger.error('Failed to stop local recording.', err);
+            });
+    }
+
+    // eslint-disable-next-line flowtype/no-types-missing-file-annotation
+    _switchToNewSession: (string) => void;
+
+    /**
+     * Switches to a new local recording session.
+     * RecordingController.registerEvents.
+     *
+     * @param {string} sessionToken - The session Token.
+     * @returns {void}
+     */
+    _switchToNewSession(sessionToken) {
+        this._currentSessionToken = sessionToken;
+        logger.log(`New session: ${this._currentSessionToken}, `
+            + `format: ${this._format}`);
+        this._adapter = new WebmAdapter();
+        sessionManager.createSession(sessionToken, this._format);
+    }
+
+    /**
+     * Function for removing audio source from AudioContext.
+     *
+     * @param {string} id - Participant id.
+     * @returns {void}
+     */
+    removeParticipantAudioStream(id) {
+        if (this._adapter.removeAudioStreamsById) {
+            this._adapter.removeAudioStreamsById(id);
+        }
+    }
+}
+
+/**
+ * Global singleton of {@code LocalRecordingController}.
+ */
+export const recordingController = new LocalRecordingController();

--- a/react/features/riff-local-recording/controller/index.js
+++ b/react/features/riff-local-recording/controller/index.js
@@ -1,0 +1,1 @@
+export * from './RecordingController';

--- a/react/features/riff-local-recording/helpers.js
+++ b/react/features/riff-local-recording/helpers.js
@@ -1,0 +1,139 @@
+/* eslint-disable require-jsdoc */
+
+import {
+    COMMAND_START,
+    COMMAND_STOP,
+    PROPERTY_STATS
+} from './constants';
+
+
+// Determine if the browser supports screen sharing
+function isScreenShareSourceAvailable() {
+    return Boolean(navigator.getDisplayMedia
+              || navigator.mediaDevices.getDisplayMedia
+              || navigator.mediaDevices.getSupportedConstraints().mediaSource);
+}
+
+class AudioStreamsMixer {
+
+    initializeAudioContext(streamsArr) {
+        this.audioContext = new AudioContext();
+        this.dest = this.audioContext.createMediaStreamDestination();
+        this.sources = [];
+
+        streamsArr.length && streamsArr.forEach(stream => {
+            if (stream.stream.getAudioTracks().length) {
+                this.addStream(stream);
+            }
+        });
+    }
+
+    addStream({ stream, id }) {
+        const sources = stream.getAudioTracks().map(track =>
+            this.audioContext.createMediaStreamSource(new MediaStream([ track ])));
+
+        sources.forEach(source => {
+
+            // Add new source to the current sources being mixed
+            this.sources.push({ id,
+                source });
+            source.connect(this.dest);
+
+        });
+    }
+
+    getAudioTracks() {
+        return this.dest.stream.getAudioTracks();
+    }
+
+    flushAllSources() {
+        this.sources.forEach(source => {
+            source.source.disconnect(this.dest);
+        });
+
+        this.sources = [];
+    }
+
+    cleanup() {
+        this.audioContext.close();
+    }
+
+    removeAudioSouce(id) {
+        const sources = [];
+
+        this.sources.forEach(source => {
+            if (source.id === id) {
+                source.source.disconnect(this.dest);
+            } else {
+                sources.push(source);
+            }
+        });
+
+        this.sources = sources;
+    }
+}
+
+const audioStreamsMixer = new AudioStreamsMixer();
+
+export const addNewAudioStream = (newParticipantStream, id) => {
+    audioStreamsMixer.addStream({ stream: newParticipantStream,
+        id });
+};
+
+export const removeAudioStream = id => audioStreamsMixer.removeAudioSouce(id);
+
+export const cleanupAudioContext = () => {
+    audioStreamsMixer.flushAllSources();
+    audioStreamsMixer.cleanup();
+};
+
+const createDesktopTrack = () => {
+
+    const getDesktopStreamPromise = navigator.mediaDevices.getDisplayMedia({ video: { displaySurface: 'browser' },
+        audio: false });
+
+    return getDesktopStreamPromise.then(desktopStream => desktopStream, error => {
+        throw new Error(error);
+    });
+};
+
+export const getCombinedStream = async participantStreams => {
+    if (!isScreenShareSourceAvailable()) {
+        throw new Error('Screen sharing is not supported in this browser.');
+    }
+
+    return createDesktopTrack().then(desktopStream => {
+        audioStreamsMixer.initializeAudioContext(participantStreams);
+        const audioTrack = audioStreamsMixer.getAudioTracks() || [];
+
+        return new MediaStream(desktopStream.getVideoTracks().concat(audioTrack));
+    })
+    .catch(error => Promise.reject(error));
+};
+
+export const stopLocalVideo = recorderStream => recorderStream.getAudioTracks().forEach(track => track.stop());
+
+export const stopLocalRecordingHandling = user => {
+
+    const userLocRecStats = user?._properties && user._properties[PROPERTY_STATS];
+    const checkUserLocalRecordingStatus = JSON.parse(userLocRecStats || null);
+
+    if (checkUserLocalRecordingStatus?.isRecording) {
+        user._conference.removeCommand(COMMAND_START);
+        user._conference.sendCommand(COMMAND_STOP, {
+            attributes: {
+                sessionToken: checkUserLocalRecordingStatus.currentSessionToken
+            }
+        });
+    }
+};
+
+export const createUserAudioTrack = () => {
+
+    const getUserAudioStreamPromise = navigator.mediaDevices.getUserMedia({ video: false,
+        audio: true });
+
+    return getUserAudioStreamPromise.then(audioStream => audioStream, error => {
+        throw new Error(error);
+    });
+};

--- a/react/features/riff-local-recording/index.js
+++ b/react/features/riff-local-recording/index.js
@@ -1,0 +1,5 @@
+export * from './actions';
+export * from './actionTypes';
+export * from './components';
+export * from './controller';
+

--- a/react/features/riff-local-recording/logger.js
+++ b/react/features/riff-local-recording/logger.js
@@ -1,0 +1,5 @@
+// @flow
+
+import { getLogger } from '../base/logging/functions';
+
+export default getLogger('features/riff-local-recording');

--- a/react/features/riff-local-recording/middleware.js
+++ b/react/features/riff-local-recording/middleware.js
@@ -1,0 +1,199 @@
+/* eslint-disable max-len */
+/* @flow */
+
+import { APP_WILL_UNMOUNT } from '../base/app/actionTypes';
+import {
+    CONFERENCE_JOINED,
+    CONFERENCE_WILL_LEAVE
+} from '../base/conference/actionTypes';
+import { openDialog, hideDialog } from '../base/dialog/actions';
+import { i18next } from '../base/i18n';
+import { MEDIA_TYPE } from '../base/media';
+import { SET_AUDIO_MUTED } from '../base/media/actionTypes';
+import { PARTICIPANT_JOINED, PARTICIPANT_LEFT } from '../base/participants/actionTypes';
+import { MiddlewareRegistry } from '../base/redux';
+import { SETTINGS_UPDATED } from '../base/settings/actionTypes';
+import { TRACK_ADDED } from '../base/tracks/actionTypes';
+import {
+    NOTIFICATION_TIMEOUT_TYPE,
+    showNotification
+} from '../notifications';
+import {
+    VIDEO_PLAYER_PARTICIPANT_NAME,
+    YOUTUBE_PLAYER_PARTICIPANT_NAME
+} from '../shared-video/constants';
+
+import {
+    LOCAL_RECORDING_ENGAGED,
+    LOCAL_RECORDING_UNENGAGED
+} from './actionTypes';
+import {
+    localRecordingEngaged,
+    localRecordingUnengaged,
+    localRecordingStats,
+    setSharedVideoId
+} from './actions';
+import DownloadInfoDialog from './components/DownloadInfoDialog';
+import { recordingController } from './controller/RecordingController';
+import { createUserAudioTrack } from './helpers';
+
+declare var APP: Object;
+declare var config: Object;
+
+MiddlewareRegistry.register(({ getState, dispatch }) => next => action => {
+    const result = next(action);
+
+    const isEngagedStatus = () => getState()['features/riff-local-recording'].isEngaged;
+    const isRecordingStatus = () => getState()['features/riff-local-recording'].stats?.isRecording;
+
+    const getLocalRecordingMessage = (messageKey, messageParams) => {
+        return {
+            title: i18next.t('localRecording.localRecording'),
+            description: i18next.t(messageKey, messageParams)
+        };
+    };
+
+    const onSharingVideoAdded = participantId => createUserAudioTrack()
+        .then(audioStream => {
+            recordingController.onNewParticipantAudioStreamAdded(audioStream, participantId);
+        })
+        .catch(error => console.log(error));
+
+    switch (action.type) {
+    case CONFERENCE_JOINED: {
+        const enableRiffLocalRecording = config.toolbarButtons
+            && config.toolbarButtons.includes('localrecording');
+        const isLocalRecordingEnabled = Boolean(
+            enableRiffLocalRecording
+            && typeof APP === 'object'
+        );
+
+        if (!isLocalRecordingEnabled) {
+            break;
+        }
+
+        // realize the delegates on recordingController, allowing the UI to
+        // react to state changes in recordingController.
+        recordingController.onStateChanged = isEngaged => {
+            const currentIsEngagedStatus = isEngagedStatus();
+
+            if (isEngaged && !currentIsEngagedStatus) {
+                dispatch(localRecordingEngaged());
+            } else if (!isEngaged && currentIsEngagedStatus) {
+                dispatch(localRecordingUnengaged());
+            }
+        };
+
+        recordingController.onStatusUpdated = stats => {
+            dispatch(localRecordingStats(stats));
+
+            if (stats?.isRecording) {
+                const { sharedVideoId } = getState()['features/riff-local-recording'];
+
+                // if video sharing is turned on we need to record video audio by user microfon
+                if (sharedVideoId) {
+                    onSharingVideoAdded(sharedVideoId);
+                }
+            }
+        };
+
+        recordingController.onWarning = (messageKey, messageParams) => {
+            dispatch(showNotification(getLocalRecordingMessage(messageKey, messageParams), NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+        };
+
+        recordingController.onNotify = (messageKey, messageParams) => {
+            dispatch(showNotification(getLocalRecordingMessage(messageKey, messageParams), NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+        };
+
+        recordingController.onMemoryExceeded = isExceeded => {
+            dispatch((isExceeded ? openDialog : hideDialog)(DownloadInfoDialog));
+        };
+
+        const { room: meetingRoomName, conference } = getState()['features/base/conference'];
+
+        recordingController.registerEvents(conference, meetingRoomName);
+
+        break;
+    }
+
+    case APP_WILL_UNMOUNT:
+        recordingController.onStateChanged = null;
+        recordingController.onNotify = null;
+        recordingController.onWarning = null;
+        break;
+
+    case SET_AUDIO_MUTED:
+        recordingController.setMuted(action.muted);
+        break;
+
+    case SETTINGS_UPDATED: {
+        const { micDeviceId } = getState()['features/base/settings'];
+
+        if (micDeviceId) {
+            recordingController.setMicDevice(micDeviceId);
+        }
+        break;
+    }
+
+    case TRACK_ADDED: {
+        const isRecording = isRecordingStatus();
+        const { conference } = getState()['features/base/conference'];
+        const { track } = action;
+
+        if (!track || track.local || !isRecording || !conference) {
+            return;
+        }
+
+        if (track.jitsiTrack && track.jitsiTrack.getType() === MEDIA_TYPE.AUDIO) {
+            recordingController.onNewParticipantAudioStreamAdded(track.jitsiTrack.stream, track.participantId);
+        }
+        break;
+    }
+
+    case CONFERENCE_WILL_LEAVE: {
+        if (isRecordingStatus()) {
+            recordingController.stopRecording();
+        }
+        break;
+    }
+
+    case PARTICIPANT_JOINED: {
+        const participant = action.participant;
+
+        if (participant.name === VIDEO_PLAYER_PARTICIPANT_NAME
+        || participant.name === YOUTUBE_PLAYER_PARTICIPANT_NAME) {
+            dispatch(setSharedVideoId(participant.id));
+            if (isRecordingStatus()) {
+                onSharingVideoAdded(participant.id);
+            }
+        }
+
+        break;
+    }
+
+    case PARTICIPANT_LEFT: {
+        if (isRecordingStatus()) {
+            recordingController.removeParticipantAudioStream(action.participant.id);
+        }
+        const { sharedVideoId } = getState()['features/riff-local-recording'];
+
+        if (sharedVideoId === action.participant.id) {
+            dispatch(setSharedVideoId(''));
+        }
+        break;
+
+    }
+
+    case LOCAL_RECORDING_ENGAGED: {
+        dispatch(showNotification(getLocalRecordingMessage('Local recording has started.'), NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+        break;
+    }
+
+    case LOCAL_RECORDING_UNENGAGED: {
+        dispatch(showNotification(getLocalRecordingMessage('Local recording has stopped.'), NOTIFICATION_TIMEOUT_TYPE.MEDIUM));
+        break;
+    }
+    }
+
+    return result;
+});

--- a/react/features/riff-local-recording/recording/RecordingAdapter.js
+++ b/react/features/riff-local-recording/recording/RecordingAdapter.js
@@ -1,0 +1,85 @@
+import JitsiMeetJS from '../../base/lib-jitsi-meet';
+
+/**
+ * Base class for recording backends.
+ */
+export class RecordingAdapter {
+
+    /**
+     * Starts recording.
+     *
+     * @param {string} micDeviceId - The microphone to record on.
+     * @returns {Promise}
+     */
+    start(/* eslint-disable no-unused-vars */
+            micDeviceId/* eslint-enable no-unused-vars */) {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Stops recording.
+     *
+     * @returns {Promise}
+     */
+    stop() {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Export the recorded and encoded audio file.
+     *
+     * @returns {Promise<Object>}
+     */
+    exportRecordedData() {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Mutes or unmutes the current recording.
+     *
+     * @param {boolean} muted - Whether to mute or to unmute.
+     * @returns {Promise}
+     */
+    setMuted(/* eslint-disable no-unused-vars */
+            muted/* eslint-enable no-unused-vars */) {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Changes the current microphone.
+     *
+     * @param {string} micDeviceId - The new microphone device ID.
+     * @returns {Promise}
+     */
+    setMicDevice(/* eslint-disable no-unused-vars */
+            micDeviceId/* eslint-enable no-unused-vars */) {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Helper method for getting an audio {@code MediaStream}. Use this instead
+     * of calling browser APIs directly.
+     *
+     * @protected
+     * @param {number} micDeviceId - The ID of the current audio device.
+     * @returns {Promise}
+     */
+    _getAudioStream(micDeviceId) {
+        return JitsiMeetJS.createLocalTracks({
+            devices: [ 'audio' ],
+            micDeviceId
+        }).then(result => {
+            if (result.length !== 1) {
+                throw new Error('Unexpected number of streams '
+                    + 'from createLocalTracks.');
+            }
+            const mediaStream = result[0].stream;
+
+            if (mediaStream === undefined) {
+                throw new Error('Failed to create local track.');
+            }
+
+            return mediaStream;
+        });
+    }
+}

--- a/react/features/riff-local-recording/recording/Utils.js
+++ b/react/features/riff-local-recording/recording/Utils.js
@@ -1,0 +1,20 @@
+/**
+ * Force download of Blob in browser by faking an <a> tag.
+ *
+ * @param {Blob} blob - Base64 URL.
+ * @param {string} fileName - The filename to appear in the download dialog.
+ * @returns {void}
+ */
+export function downloadBlob(blob, fileName = 'recording.webm') {
+    const base64Url = window.URL.createObjectURL(blob);
+
+    // fake a anchor tag
+    const a = document.createElement('a');
+
+    a.style = 'display: none';
+    a.href = base64Url;
+    a.download = fileName;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+}

--- a/react/features/riff-local-recording/recording/index.js
+++ b/react/features/riff-local-recording/recording/index.js
@@ -1,0 +1,2 @@
+export * from './RecordingAdapter';
+export * from './Utils';

--- a/react/features/riff-local-recording/reducer.js
+++ b/react/features/riff-local-recording/reducer.js
@@ -1,0 +1,51 @@
+import { ReducerRegistry } from '../base/redux';
+
+import * as actionTypes from './actionTypes';
+
+const DEFAULT_STATE = {
+    /**
+     * Is local recording engaged.
+     *
+     * @type {boolean}
+     */
+    isEngaged: false,
+
+    /**
+     * Local recording statistics.
+     *
+     * @public
+     * @type {Object}
+     */
+    stats: undefined
+};
+
+ReducerRegistry.register('features/riff-local-recording', (state = DEFAULT_STATE, action) => {
+
+    switch (action.type) {
+
+    case actionTypes.LOCAL_RECORDING_ENGAGED: {
+        return {
+            ...state,
+            isEngaged: true
+        };
+    }
+
+    case actionTypes.LOCAL_RECORDING_UNENGAGED:
+        return { ...DEFAULT_STATE };
+
+    case actionTypes.LOCAL_RECORDING_STATS:
+        return {
+            ...state,
+            stats: {
+                ...action.stats
+            }
+        };
+    case actionTypes.LOCAL_RECORDING_SET_SHARED_VIDEO_ID:
+        return {
+            ...state,
+            sharedVideoId: action.id
+        };
+    default:
+        return state;
+    }
+});

--- a/react/features/riff-local-recording/session/SessionManager.js
+++ b/react/features/riff-local-recording/session/SessionManager.js
@@ -1,0 +1,439 @@
+/* @flow */
+
+import Bourne from '@hapi/bourne';
+import { jitsiLocalStorage } from '@jitsi/js-utils';
+
+import logger from '../logger';
+
+/**
+ * Gets high precision system time.
+ *
+ * @returns {number}
+ */
+function highPrecisionTime(): number {
+    return window.performance
+        && window.performance.now
+        && window.performance.timing
+        && window.performance.timing.navigationStart
+        ? window.performance.now() + window.performance.timing.navigationStart
+        : Date.now();
+}
+
+// Have to use string literal here, instead of Symbols,
+// because these values need to be JSON-serializible.
+
+/**
+ * Types of SessionEvents.
+ */
+const SessionEventType = Object.freeze({
+    /**
+     * Start of local recording session. This is recorded when the
+     * {@code RecordingController} receives the signal to start local recording,
+     * before the actual adapter is engaged.
+     */
+    SESSION_STARTED: 'SESSION_STARTED',
+
+    /**
+     * Start of a continuous segment. This is recorded when the adapter is
+     * engaged. Can happen multiple times in a local recording session,
+     * due to browser reloads or switching of recording device.
+     */
+    SEGMENT_STARTED: 'SEGMENT_STARTED',
+
+    /**
+     * End of a continuous segment. This is recorded when the adapter unengages.
+     */
+    SEGMENT_ENDED: 'SEGMENT_ENDED'
+});
+
+/**
+ * Represents an event during a local recording session.
+ * The event can be either that the adapter started recording, or stopped
+ * recording.
+ */
+type SessionEvent = {
+
+    /**
+     * The type of the event.
+     * Should be one of the values in {@code SessionEventType}.
+     */
+    type: string,
+
+    /**
+     * The timestamp of the event.
+     */
+    timestamp: number
+};
+
+/**
+ * Representation of the metadata of a segment.
+ */
+type SegmentInfo = {
+
+    /**
+     * The length of gap before this segment, in milliseconds.
+     * Mull if unknown.
+     */
+    gapBefore?: ?number,
+
+    /**
+     * The duration of this segment, in milliseconds.
+     * Null if unknown or the segment is not finished.
+     */
+    duration?: ?number,
+
+    /**
+     * The start time, in milliseconds.
+     */
+    start?: ?number,
+
+    /**
+     * The end time, in milliseconds.
+     * Null if unknown, the segment is not finished, or the recording is
+     * interrupted (e.g. Browser reload).
+     */
+    end?: ?number
+};
+
+/**
+ * Representation of metadata of a local recording session.
+ */
+type SessionInfo = {
+
+    /**
+     * The session token.
+     */
+    sessionToken: string,
+
+    /**
+     * The start time of the session.
+     */
+    start: ?number,
+
+    /**
+     * The recording format.
+     */
+    format: string,
+
+    /**
+     * Array of segments in the session.
+     */
+    segments: SegmentInfo[]
+}
+
+/**
+ * {@code localStorage} Key.
+ */
+const LOCAL_STORAGE_KEY = 'localRecordingMetadataVersion1';
+
+/**
+ * SessionManager manages the metadata of each segment during each local
+ * recording session.
+ *
+ * A segment is a continuous portion of recording done using the same adapter
+ * on the same microphone device.
+ *
+ * Browser refreshes, switching of microphone will cause new segments to be
+ * created.
+ *
+ * A recording session can consist of one or more segments.
+ */
+class SessionManager {
+
+    /**
+     * The metadata.
+     */
+    _sessionsMetadata = {
+    };
+
+    /**
+     * Constructor.
+     */
+    constructor() {
+        this._loadMetadata();
+    }
+
+    /**
+     * Loads metadata from localStorage.
+     *
+     * @private
+     * @returns {void}
+     */
+    _loadMetadata() {
+        const dataStr = jitsiLocalStorage.getItem(LOCAL_STORAGE_KEY);
+
+        if (dataStr !== null) {
+            try {
+                const dataObject = Bourne.parse(dataStr);
+
+                this._sessionsMetadata = dataObject;
+            } catch (e) {
+                logger.warn('Failed to parse localStorage item.');
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * Persists metadata to localStorage.
+     *
+     * @private
+     * @returns {void}
+     */
+    _saveMetadata() {
+        jitsiLocalStorage.setItem(LOCAL_STORAGE_KEY,
+            JSON.stringify(this._sessionsMetadata));
+    }
+
+    /**
+     * Creates a session if not exists.
+     *
+     * @param {string} sessionToken - The local recording session token.
+     * @param {string} format - The local recording format.
+     * @returns {void}
+     */
+    createSession(sessionToken: string, format: string) {
+        if (this._sessionsMetadata[sessionToken] === undefined) {
+            this._sessionsMetadata[sessionToken] = {
+                format,
+                events: []
+            };
+            this._sessionsMetadata[sessionToken].events.push({
+                type: SessionEventType.SESSION_STARTED,
+                timestamp: highPrecisionTime()
+            });
+            this._saveMetadata();
+        } else {
+            logger.warn(`Session ${sessionToken} already exists`);
+        }
+    }
+
+    /**
+     * Gets all the Sessions.
+     *
+     * @returns {SessionInfo[]}
+     */
+    getSessions(): SessionInfo[] {
+        const sessionTokens = Object.keys(this._sessionsMetadata);
+        const output = [];
+
+        for (let i = 0; i < sessionTokens.length; ++i) {
+            const thisSession = this._sessionsMetadata[sessionTokens[i]];
+            const newSessionInfo: SessionInfo = {
+                start: thisSession.events[0].timestamp,
+                format: thisSession.format,
+                sessionToken: sessionTokens[i],
+                segments: this.getSegments(sessionTokens[i])
+            };
+
+            output.push(newSessionInfo);
+        }
+
+        output.sort((a, b) => (a.start || 0) - (b.start || 0));
+
+        return output;
+    }
+
+    /**
+     * Removes session metadata.
+     *
+     * @param {string} sessionToken - The session token.
+     * @returns {void}
+     */
+    removeSession(sessionToken: string) {
+        delete this._sessionsMetadata[sessionToken];
+        this._saveMetadata();
+    }
+
+    /**
+     * Get segments of a given Session.
+     *
+     * @param {string} sessionToken - The session token.
+     * @returns {SegmentInfo[]}
+     */
+    getSegments(sessionToken: string): SegmentInfo[] {
+        const thisSession = this._sessionsMetadata[sessionToken];
+
+        if (thisSession) {
+            return this._constructSegments(thisSession.events);
+        }
+
+        return [];
+    }
+
+    /**
+     * Marks the start of a new segment.
+     * This should be invoked by {@code RecordingAdapter}s when they need to
+     * start asynchronous operations (such as switching tracks) that interrupts
+     * recording.
+     *
+     * @param {string} sessionToken - The token of the session to start a new
+     * segment in.
+     * @returns {number} - Current segment index.
+     */
+    beginSegment(sessionToken: string): number {
+        if (this._sessionsMetadata[sessionToken] === undefined) {
+            logger.warn('Attempting to add segments to nonexistent'
+                + ` session ${sessionToken}`);
+
+            return -1;
+        }
+        this._sessionsMetadata[sessionToken].events.push({
+            type: SessionEventType.SEGMENT_STARTED,
+            timestamp: highPrecisionTime()
+        });
+        this._saveMetadata();
+
+        return this.getSegments(sessionToken).length - 1;
+    }
+
+    /**
+     * Gets the current segment index. Starting from 0 for the first
+     * segment.
+     *
+     * @param {string} sessionToken - The session token.
+     * @returns {number}
+     */
+    getCurrentSegmentIndex(sessionToken: string): number {
+        if (this._sessionsMetadata[sessionToken] === undefined) {
+            return -1;
+        }
+        const segments = this.getSegments(sessionToken);
+
+        if (segments.length === 0) {
+            return -1;
+        }
+
+        const lastSegment = segments[segments.length - 1];
+
+        if (lastSegment.end) {
+            // last segment is already ended
+            return -1;
+        }
+
+        return segments.length - 1;
+    }
+
+    /**
+     * Marks the end of the last segment in a session.
+     *
+     * @param {string} sessionToken - The session token.
+     * @returns {void}
+     */
+    endSegment(sessionToken: string) {
+        if (this._sessionsMetadata[sessionToken] === undefined) {
+            logger.warn('Attempting to end a segment in nonexistent'
+                + ` session ${sessionToken}`);
+        } else {
+            this._sessionsMetadata[sessionToken].events.push({
+                type: SessionEventType.SEGMENT_ENDED,
+                timestamp: highPrecisionTime()
+            });
+            this._saveMetadata();
+        }
+    }
+
+    /**
+     * Constructs an array of {@code SegmentInfo} from an array of
+     * {@code SessionEvent}s.
+     *
+     * @private
+     * @param {SessionEvent[]} events - The array of {@code SessionEvent}s.
+     * @returns {SegmentInfo[]}
+     */
+    _constructSegments(events: SessionEvent[]): SegmentInfo[] {
+        if (events.length === 0) {
+            return [];
+        }
+
+        const output = [];
+        let sessionStartTime = null;
+        let currentSegment: SegmentInfo = {};
+
+        /**
+         * Helper function for adding a new {@code SegmentInfo} object to the
+         * output.
+         *
+         * @returns {void}
+         */
+        function commit() {
+            if (currentSegment.gapBefore === undefined
+                || currentSegment.gapBefore === null) {
+                if (output.length > 0 && output[output.length - 1].end) {
+                    const lastSegment = output[output.length - 1];
+
+                    if (currentSegment.start && lastSegment.end) {
+                        currentSegment.gapBefore = currentSegment.start
+                            - lastSegment.end;
+                    } else {
+                        currentSegment.gapBefore = null;
+                    }
+                } else if (sessionStartTime !== null && output.length === 0) {
+                    currentSegment.gapBefore = currentSegment.start
+                        ? currentSegment.start - sessionStartTime
+                        : null;
+                } else {
+                    currentSegment.gapBefore = null;
+                }
+            }
+            currentSegment.duration = currentSegment.end && currentSegment.start
+                ? currentSegment.end - currentSegment.start
+                : null;
+            output.push(currentSegment);
+            currentSegment = {};
+        }
+
+        for (let i = 0; i < events.length; ++i) {
+            const currentEvent = events[i];
+
+            switch (currentEvent.type) {
+            case SessionEventType.SESSION_STARTED:
+                if (sessionStartTime === null) {
+                    sessionStartTime = currentEvent.timestamp;
+                } else {
+                    logger.warn('Unexpected SESSION_STARTED event.'
+                        , currentEvent);
+                }
+                break;
+            case SessionEventType.SEGMENT_STARTED:
+                if (currentSegment.start === undefined
+                    || currentSegment.start === null) {
+                    currentSegment.start = currentEvent.timestamp;
+                } else {
+                    commit();
+                    currentSegment.start = currentEvent.timestamp;
+                }
+                break;
+
+            case SessionEventType.SEGMENT_ENDED:
+                if (currentSegment.start === undefined
+                    || currentSegment.start === null) {
+                    logger.warn('Unexpected SEGMENT_ENDED event', currentEvent);
+                } else {
+                    currentSegment.end = currentEvent.timestamp;
+                    commit();
+                }
+                break;
+
+            default:
+                logger.warn('Unexpected error during _constructSegments');
+                break;
+            }
+        }
+        if (currentSegment.start) {
+            commit();
+        }
+
+        return output;
+    }
+
+}
+
+/**
+ * Global singleton of {@code SessionManager}.
+ */
+export const sessionManager = new SessionManager();
+
+// For debug only. To remove later.
+window.sessionManager = sessionManager;

--- a/react/features/riff-local-recording/session/index.js
+++ b/react/features/riff-local-recording/session/index.js
@@ -1,0 +1,1 @@
+export * from './SessionManager';

--- a/react/features/toolbox/components/web/Toolbox.js
+++ b/react/features/toolbox/components/web/Toolbox.js
@@ -51,6 +51,7 @@ import {
     LiveStreamButton,
     RecordButton
 } from '../../../recording';
+import RiffLocalRecordingButton from '../../../riff-local-recording/components/LocalRecordingButton';
 import { isSalesforceEnabled } from '../../../salesforce/functions';
 import {
     isScreenAudioSupported,
@@ -731,6 +732,12 @@ class Toolbox extends Component<Props> {
             group: 2
         };
 
+        const localRecording = {
+            key: 'localrecording',
+            Content: RiffLocalRecordingButton,
+            group: 2
+        };
+
         const livestreaming = {
             key: 'livestreaming',
             Content: LiveStreamButton,
@@ -837,6 +844,7 @@ class Toolbox extends Component<Props> {
             security,
             cc,
             recording,
+            localRecording,
             livestreaming,
             linkToSalesforce,
             shareVideo,


### PR DESCRIPTION
## Description
Add the Riff Local Recording functionality to the jitsi-meet 7439 version.

Cherry-picked previous Riff Local Recording commits from `riff/mods_7287` into `riff/mods_7439`

There was a potential for conflict with the new jitsi-meet local recording, but none seems to have manifested during testing.

## Motivation and context
While this new version of jitsi-meet has its own local recording functionality, it does not meet the requirements for Riff.
Therefore this PR adds the local recording functionality implemented by Riff.

## How has this been tested?
- Tested these changes on Sandbox1. Larry and I tested these changes together with various local-recording feature combinations.

## Types of changes
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
- ✅ My code follows the code style of this project.
- ✅ Ran `make lint` and `make build` with no warnings or errors. **[REQUIRED]**
- ✅ All new and existing tests passed.
