### PR TITLE
Add support for multiplexed email field (RA-768)

### DIFF
--- a/react/features/base/participants/functions.js
+++ b/react/features/base/participants/functions.js
@@ -5,6 +5,7 @@ import type { Store } from 'redux';
 
 import { i18next } from '../../base/i18n';
 import { isStageFilmstripAvailable } from '../../filmstrip/functions';
+import { riffTryParseEmail } from '../../riff-integration/functions';
 import { GRAVATAR_BASE_URL, isCORSAvatarURL } from '../avatar';
 import { getMultipleVideoSupportFeatureFlag, getSourceNameSignalingFeatureFlag } from '../config';
 import { JitsiParticipantConnectionStatus, JitsiTrackStreamingStatus } from '../lib-jitsi-meet';
@@ -38,7 +39,7 @@ const AVATAR_CHECKER_FUNCTIONS = [
                 || config.gravatarBaseURL
                 || GRAVATAR_BASE_URL;
 
-            return getGravatarURL(participant.email, gravatarBaseURL);
+            return getGravatarURL(riffTryParseEmail(participant.email), gravatarBaseURL);
         }
 
         return null;

--- a/react/features/riff-integration/functions.js
+++ b/react/features/riff-integration/functions.js
@@ -59,6 +59,33 @@ function getRiffState(state) {
 }
 
 /**
+ * Parse a [potentially] multiplexed email value and return
+ * the actual email, if provided. Otherwise return input.
+ *
+ * @param {string} email - The string to parse: we expect either
+ *  an actual email or a stringified json object which may contain
+ *  an email
+ *
+ * @returns {string} The parsed email, or the input string on failure
+ */
+function riffTryParseEmail(email) {
+    try {
+        const multiplexedEmail = JSON.parse(email);
+
+        // ensure it's an object and not null / other parseable but not-objects
+        if (multiplexedEmail && typeof multiplexedEmail === 'object') {
+            // if we weren't provided an email in the multiplexed object,
+            // just return the input string
+            return multiplexedEmail.email ?? email;
+        }
+
+        return email;
+    } catch (err) {
+        return email;
+    }
+}
+
+/**
  * Sends an utterance to the riff data server if the user is currently
  * in a meeting. If the user has yet to join or has left a meeting, drop it.
  *
@@ -136,4 +163,5 @@ function detachSibilant() {
 export {
     attachSibilant,
     getRiffState,
+    riffTryParseEmail,
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
Adds the ability to pass in a stringified JSON object in place of the email field. If a regular email is passed instead of a stringified object, the gravatars should still work. 

## Motivation and context
Required (for now) to get additional information to Jigasi without significant further changes.
See: https://esme-learning.atlassian.net/browse/RA-768

## How has this been tested?
Tested locally

## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)
- ✅ New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Please go over all the following points. -->
<!--- Again, remove any lines which don't apply. -->
<!--- Pull Requests that don't fulfill all [REQUIRED] requisites are likely -->
<!--- to be sent back to you for correction or will be rejected.  -->
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**
