### PR TITLE
Add ContextMenu to Riff local recording component (RA-897)

### DIFF
--- a/react/features/riff-local-recording/components/LocalRecordingButton.js
+++ b/react/features/riff-local-recording/components/LocalRecordingButton.js
@@ -11,9 +11,11 @@ import { recordingController } from '../controller/RecordingController';
 
 import LocalRecordingDialog from './LocalRecordingDialog';
 
+
 const LocalRecordingButton = ({
     toggleLocalRecordingDialog,
     showLabel,
+    contextMenu,
     isEngagedLocally
 }) => {
     const doToggleLocalRecordingDialog = () => toggleLocalRecordingDialog();
@@ -28,6 +30,7 @@ const LocalRecordingButton = ({
     return (
         <ToolboxItem
             accessibilityLabel = 'Local Recording'
+            contextMenu = { contextMenu }
             icon = { IconRec }
             label = { `${isEngagedLocally ? 'Stop' : 'Start'} Local Recording` }
             onClick = { isEngagedLocally ? doStopLocalRecording : doToggleLocalRecordingDialog }
@@ -36,6 +39,7 @@ const LocalRecordingButton = ({
 };
 
 LocalRecordingButton.propTypes = {
+    contextMenu: PropTypes.bool,
     isEngagedLocally: PropTypes.bool,
     showLabel: PropTypes.bool,
     toggleLocalRecordingDialog: PropTypes.func


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Description
With the latest release of Jitsi meet, to get the proper background on the local recording button, the ContextMenu setting had to be passed to the component.  If that was not set, the component got added as a `<li>` item rather than a `<div>` and also got a different `<class>` which affected the display from the CSS.

## Motivation and context
The Start Local Recording button would become all white upon hovering over it and would be illegible.

## How has this been tested?
Tested locally in debugger and then tested the changes on Sandbox3.


## Types of changes
<!--- What types of changes does your code introduce? -->
<!--- Please remove all lines which don't apply. -->
- ✅ Bug fix (non-breaking change which fixes an issue)


## Checklist:
- ✅ My code follows the code style of this project. **[REQUIRED]**
- ✅ All new and existing tests passed. **[REQUIRED]**

